### PR TITLE
fix usage of reserved keyword in mysql 5.7

### DIFF
--- a/src/Packagist/WebBundle/Entity/SshCredentials.php
+++ b/src/Packagist/WebBundle/Entity/SshCredentials.php
@@ -31,7 +31,7 @@ class SshCredentials
     /**
      * @var string
      *
-     * @ORM\Column(name="key", type="text")
+     * @ORM\Column(name="`key`", type="text")
      */
     private $key;
 


### PR DESCRIPTION
The submission of a ssh key results in a mysql error. The "key" is reserved in mysql 5.7.