### PR TITLE
Update about.html.twig

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/About/about.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/About/about.html.twig
@@ -70,6 +70,8 @@ composer config --global --auth http-basic.{{ app.request.getHttpHost() }} {{ ap
                 Search for Packagist in the list of Project Services.
                 Check the "Active" box, enter your packagist.org username and API token.
                 Save your changes and you're done.
+		<br>
+		If GitLab is running on a local network make sure you enable Admin -> Settings -> Network -> Outbound Requests -> Allow requests to the local network from web-hooks and services
             </p>
 
             <h3>GitLab Group Hooks</h3>


### PR DESCRIPTION
I've got an error when i'm trying to add the Webhook for GitLab

>"Gitlab::HTTP::BlockedUrlError","exception.message":"URL 'https://xxx.xxxx.xxx/api/update-package?username=admin\u0026apiToken=XXXXXXXXXXXXXXXX' is blocked: Requests to the local network are not allowed"

added hint if the GitLab server running on a local network