### PR TITLE
Provide integration with Gitlab/Github/Bitbucket API update hooks

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -51,6 +51,7 @@ security:
         - { path: (^(/change-password|/profile/|/search|/logout|/packages/|/versions/))+, role: ROLE_USER }
         - { path: (^(/packages.json$|/p/|/zipball/|/downloads/))+, role: ROLE_USER }
         - { path: (^(/api/webhook-invoke/))+, role: ROLE_USER }
+        - { path: (^(/api/(create-package|update-package|github|bitbucket)))$, role: ROLE_MAINTAINER }
         - { path: ^/$, role: ROLE_USER }
 
         # Maintainers


### PR DESCRIPTION
Provide integration with Gitlab API update hooks. 

see https://github.com/vtsykun/packeton#gitlab-service

Unsure if this should just be applied to `ROLE_USER` rather than `ROLE_MAINTAINER`, but `ROLE_MAINTAINER` makes the most sense to me, unless normal users should still be able to trigger package updates.