### PR TITLE
Don't provide zipballs for metapackages.

### DIFF
--- a/src/Packagist/WebBundle/Resources/views/Package/package.html.twig
+++ b/src/Packagist/WebBundle/Resources/views/Package/package.html.twig
@@ -79,7 +79,7 @@
             <div class="col-xs-2 text-xs-left text-sm-right"><strong>Releases</strong></div>
             <div class="col-xs-12 col-sm-10">
                 {% for version in package.versions %}
-                    {%- if version.dist -%}
+                    {%- if (version.dist) and (version.type != 'metapackage') -%}
                         {% set url = '?token=' ~ app.user.username ~ ':' ~ app.user.apiToken %}
                         <a href="{{ version.dist['url'] ~ url }}" title="dist-reference: {{ version.dist['reference'] }}">
                             {{ version.version }}


### PR DESCRIPTION
Metapackages cannot be installed/downloaded as a zip/tarball.

So they should not be linked to otherwise when someone tries to click them, an exception is thrown:

```
request.CRITICAL: Uncaught PHP Exception RuntimeException: 

"Could not delete /tmp/composer_archive5f7347e738260.zip: unlink(/tmp/composer_archive5f7347e738260.zip): No such file or directory" 
at /var/www/application/vendor/composer/composer/src/Composer/Util/Filesystem.php line 217 {"exception":"[object] (RuntimeException(code: 0): Could not delete /tmp/composer_archive5f7347e738260.zip: unlink(/tmp/composer_archive5f7347e738260.zip): 
No such file or directory at /var/www/application/vendor/composer/composer/src/Composer/Util/Filesystem.php:217)
```

due to this [line](https://github.com/composer/composer/blob/1.9.3/src/Composer/Downloader/DownloadManager.php#L147-L149) in composer when it tries to zip up the metapackage.