### PR TITLE
Regenerate missing dist files referenced by older composer.lock files.

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -143,3 +143,5 @@ packagist_web:
         format: zip
         basedir: '%kernel.root_dir%/zipball'
         endpoint: '%packagist_dist_host%'
+        # How long to cache archive responses for.
+        cache_duration: 1800

--- a/src/Packagist/WebBundle/Controller/ProviderController.php
+++ b/src/Packagist/WebBundle/Controller/ProviderController.php
@@ -97,6 +97,7 @@ class ProviderController extends Controller
      */
     public function zipballAction(Package $package, $hash)
     {
+      /** @var DistManager $distManager */
         $distManager = $this->container->get(DistManager::class);
         if (false === \preg_match('{[a-f0-9]{40}}i', $hash, $match)) {
             return new JsonResponse(['status' => 'error', 'message' => 'Not Found'], 404);
@@ -111,9 +112,9 @@ class ProviderController extends Controller
             }
         );
 
-        // Try to download from cache
+        // Try to download from cache or create the zip if missing.
         if ($versions->count() === 0) {
-            list($path, $versionName) = $distManager->lookupInCache($match[0], $package->getName());
+            list($path, $versionName) = $distManager->resolvePackage($package, $match[0]);
             if (null !== $versionName) {
                 $version = $package->getVersions()
                     ->filter(

--- a/src/Packagist/WebBundle/DependencyInjection/Configuration.php
+++ b/src/Packagist/WebBundle/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('format')->defaultValue('zip')->end()
                         ->scalarNode('basedir')->cannotBeEmpty()->end()
                         ->scalarNode('endpoint')->cannotBeEmpty()->end()
+                        ->scalarNode('cache_duration')->defaultValue(30 * 60)->end()
                         ->booleanNode('include_archive_checksum')->defaultFalse()->end()
                     ->end()
                 ->end()

--- a/src/Packagist/WebBundle/Entity/Version.php
+++ b/src/Packagist/WebBundle/Entity/Version.php
@@ -971,4 +971,10 @@ class Version
     {
         return $this->name.' '.$this->version.' ('.$this->normalizedVersion.')';
     }
+
+    public function __clone()
+    {
+        // Ensure that the clone can't persist over the original.
+        $this->id = null;
+    }
 }

--- a/src/Packagist/WebBundle/Resources/config/services.yml
+++ b/src/Packagist/WebBundle/Resources/config/services.yml
@@ -206,6 +206,8 @@ services:
         arguments:
             - '@packagist.dist_config'
             - '@packagist_factory'
+            - '@logger'
+            - '@packagist_cache'
 
     Packagist\WebBundle\Composer\PackagistFactory:
         alias: packagist_factory

--- a/src/Packagist/WebBundle/Service/DistConfig.php
+++ b/src/Packagist/WebBundle/Service/DistConfig.php
@@ -44,6 +44,14 @@ class DistConfig
     }
 
     /**
+     * @return int
+     */
+    public function getCacheDuration(): int
+    {
+        return $this->config['cache_duration'] ?? 1800;
+    }
+
+    /**
      * @param string $name
      * @param string $reference
      * @param string $version

--- a/src/Packagist/WebBundle/Service/DistManager.php
+++ b/src/Packagist/WebBundle/Service/DistManager.php
@@ -6,8 +6,12 @@ namespace Packagist\WebBundle\Service;
 
 use Composer\Factory;
 use Composer\IO\NullIO;
+use Composer\Package\PackageInterface;
+use Doctrine\Common\Cache\Cache;
 use Packagist\WebBundle\Composer\PackagistFactory;
+use Packagist\WebBundle\Entity\Package;
 use Packagist\WebBundle\Entity\Version;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
@@ -17,15 +21,23 @@ class DistManager
     private $config;
     private $fileSystem;
     private $packagistFactory;
+    private $logger;
+    private $cache;
 
-    public function __construct(DistConfig $config, PackagistFactory $packagistFactory)
-    {
+    public function __construct(
+        DistConfig $config,
+        PackagistFactory $packagistFactory,
+        LoggerInterface $logger,
+        Cache $cache
+    ) {
         $this->config = $config;
         $this->packagistFactory = $packagistFactory;
         $this->fileSystem = new Filesystem();
+        $this->logger = $logger;
+        $this->cache = $cache;
     }
 
-    public function getDistPath(Version $version): ?string
+    public function getDistPath(Version $version, $forceDownload = false): ?string
     {
         $dist = $version->getDist();
         if (false === isset($dist['reference'])) {
@@ -41,7 +53,7 @@ class DistManager
             return $path;
         }
 
-        return $this->download($version);
+        return $this->download($version, $forceDownload);
     }
 
     public function lookupInCache(string $reference, string $packageName): ?array
@@ -66,7 +78,53 @@ class DistManager
         return [null, null];
     }
 
-    private function download(Version $version): ?string
+    public function resolvePackage(Package $package, string $hashRef): ?array
+    {
+        $cacheKey = self::getCacheId($package->getName(), $hashRef);
+        // Check the cache for the zip.
+        if ($cache = $this->cache->fetch($cacheKey)) {
+            if (is_array($cache) && count($cache) === 2) {
+                // Return the cached results.
+                return $cache;
+            }
+        }
+
+        [$path, $versionName] = $this->lookupInCache($hashRef, $package->getName());
+
+        if ($versionName === null) {
+            // The hash hasn't been downloaded before, attempt to download it.
+            $sortedVersions = $package->getVersions()->toArray();
+            usort($sortedVersions, [static::class, 'sortVersions']);
+            if (count($sortedVersions)) {
+                // Fetch the latest version available (most likely dev), and
+                // attempt to use it to resolve the hash.
+                $pseudoVersion = clone reset($sortedVersions);
+                // Update references to the hash where it could possibly be used.
+                $dist = $pseudoVersion->getDist();
+                $source = $pseudoVersion->getSource();
+                $dist['url'] = str_replace($dist['reference'], $hashRef, $dist['url']);
+                $source['url'] = str_replace($source['reference'], $hashRef, $source['url']);
+                $source['reference'] = $dist['reference'] = $hashRef;
+                $pseudoVersion->setDist($dist);
+                $pseudoVersion->setSource($source);
+                // Attempt to force a download of the hash.
+                if ($path = $this->getDistPath($pseudoVersion, true)) {
+                    $versionName = $this->config->guessesVersion(basename($path));
+                }
+            }
+        }
+
+        $return = [$path, $versionName];
+
+        // Cache the results here for a certain number of minutes.
+        // This avoids wasting resources scanning the filesystem or checking out
+        // repos searching for the specific hash.
+        $this->cache->save($cacheKey, $return, $this->config->getCacheDuration());
+
+        return $return;
+    }
+
+    private function download(Version $version, $forceDownload = false): ?string
     {
         $package = $version->getPackage();
         $io = new NullIO();
@@ -87,6 +145,7 @@ class DistManager
         foreach ($versions as $rootVersion) {
             if ($rootVersion->getSourceReference() === $source['reference']) {
                 $fileName = $this->config->getFileName($source['reference'], $version->getVersion());
+
                 return $archiveManager->archive(
                     $rootVersion,
                     $this->config->getArchiveFormat(),
@@ -96,6 +155,75 @@ class DistManager
             }
         }
 
+        if ($forceDownload && count($versions)) {
+            // Attempt to resolve the latest version (typically dev).
+            $sortedPackages = $versions;
+            usort($sortedPackages, [static::class, 'sortPackages']);
+            $latestPackage = reset($sortedPackages);
+            $latestPackage->setSourceReference($source['reference']);
+            // Create a forced download using the current tagged version.
+            $fileName = $this->config->getFileName($source['reference'], $version->getVersion());
+
+            try {
+                return $archiveManager->archive(
+                    $latestPackage,
+                    $this->config->getArchiveFormat(),
+                    $this->config->generateTargetDir($version->getName()),
+                    $fileName
+                );
+            } catch (\Exception $e) {
+                // Log silently.
+                $this->logger->info('['.get_class($e).'] '.$e->getMessage());
+
+                return null;
+            }
+        }
+
         return null;
     }
+
+    public static function getCacheId(string $packageName, string $hashRef): string
+    {
+        return implode('|', ['zipball', $packageName, $hashRef]);
+    }
+
+    public function sortVersions(Version $a, Version $b)
+    {
+        $aVersion = $a->getVersion();
+        $bVersion = $b->getVersion();
+        $aVersion = static::normalizeVersionForComparison($aVersion);
+        $bVersion = static::normalizeVersionForComparison($bVersion);
+
+        // equal versions are sorted by date with newer first.
+        if ($aVersion === $bVersion) {
+            return $a->getUpdatedAt() > $b->getReleasedAt() ? -1 : 1;
+        }
+
+        // the rest is sorted by version
+        return version_compare($aVersion, $bVersion);
+    }
+
+    public static function sortPackages(PackageInterface $a, PackageInterface $b)
+    {
+        $aVersion = $a->getPrettyVersion();
+        $bVersion = $b->getPrettyVersion();
+        $aVersion = static::normalizeVersionForComparison($aVersion);
+        $bVersion = static::normalizeVersionForComparison($bVersion);
+
+        // equal versions are sorted by date with newer first.
+        if ($aVersion === $bVersion) {
+            return $a->getReleaseDate() > $b->getReleaseDate() ? -1 : 1;
+        }
+
+        // the rest is sorted by version
+        return version_compare($aVersion, $bVersion);
+    }
+
+    private static function normalizeVersionForComparison($version)
+    {
+        $version = preg_replace('{^dev-.+}', '0.0.0-alpha', $version);
+
+        return $version;
+    }
+
 }


### PR DESCRIPTION
Addresses #34 

I believe the original culprit is this method in the `Updater` class.

https://github.com/vtsykun/packeton/blob/9918257c4b7a83f2a7965785f40e98ae39164d25/src/Packagist/WebBundle/Package/Updater.php#L604-L623

I think `composer.lock` files should always be the source of truth, and if a previous `composer install` ran successfully, then a future `composer install` should as well.

This bug/behaviour is more apparent when multiple repos/composer.lock reference different `dev-` versions of a package.

Potential changes to the `Updater` code are as follows:
- Add Symfony configuration for whether old `dist` files should be deleted (most flexible).
- Update logic so that it doesn't delete `dev-` or `-dev` version dists (it's rare for a tagged version to switch commit hashes, but it can still happen, and should still be supported).
- Leave as is, but redownload the file as needed using the updated `ProviderController::zipballAction` logic.

Thoughts welcome.

I think the service should definitely be able to generate missing dist hashes when needed, since composer tries to do a `git clone` anyway if its unable to download a `dist`.