### PR TITLE
added bitbucket on-premise to the webook-callees

### DIFF
--- a/src/Packagist/WebBundle/Controller/ApiController.php
+++ b/src/Packagist/WebBundle/Controller/ApiController.php
@@ -79,7 +79,7 @@ class ApiController extends Controller
     {
         // parse the payload
         $payload = json_decode($request->request->get('payload'), true);
-        if (!$payload && $request->headers->get('Content-Type') === 'application/json') {
+        if (!$payload && 0 === strpos($request->headers->get('Content-Type'), 'application/json')) {
             $payload = json_decode($request->getContent(), true);
         }
 
@@ -110,6 +110,15 @@ class ApiController extends Controller
         } elseif (isset($payload['repository']['links']['html']['href'])) { // bitbucket push event payload
             $urlRegex = '{^(?:https?://|git://|git@)?(?:api\.)?(?P<host>bitbucket\.org)[/:](?P<path>[\w.-]+/[\w.-]+?)(\.git)?/?$}i';
             $url = $payload['repository']['links']['html']['href'];
+        } elseif (isset($payload['repository']['links']['clone'][0]['href'])) { // bitbucket on-premise
+            $urlRegex = '{^(?:ssh://git@|https?://|git://|git@)?(?P<host>[a-z0-9.-]+)(?::[0-9]+/|[:/])(?P<path>[\w.-]+(?:/[\w.-]+?)+)(?:\.git|/)?$}i';
+            $url = '';
+            foreach ($payload['repository']['links']['clone'] as $id => $data) {
+                if ($data['name'] == 'ssh') {
+                    $url = $data['href'];
+                    break;
+                }
+            }
         } elseif (isset($payload['canon_url']) && isset($payload['repository']['absolute_url'])) { // bitbucket post hook (deprecated)
             $urlRegex = '{^(?:https?://|git://|git@)?(?P<host>bitbucket\.org)[/:](?P<path>[\w.-]+/[\w.-]+?)(\.git)?/?$}i';
             $url = $payload['canon_url'] . $payload['repository']['absolute_url'];
@@ -155,7 +164,7 @@ class ApiController extends Controller
         }
 
         $payload = json_decode($request->request->get('payload'), true);
-        if (!$payload && $request->headers->get('Content-Type') === 'application/json') {
+        if (!$payload && 0 === strpos($request->headers->get('Content-Type'), 'application/json')) {
             $payload = json_decode($request->getContent(), true);
         }
 


### PR DESCRIPTION
Our on-premise bitbucket wasn't able to connect due to sending some `;Charset: utf8` to the Content-Type `application/json` - so the strpos() will just cover that.
Also I discovered, that the provided data in `updatePackageAction` is quite similar to the gitlab-potion (above) - but in its clone-path diverges a bit. As we do only use `ssh` as protocol I did add that to the url-parser only.