### PR TITLE
Allow to overwrite authentication for privately hosted repos 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,8 @@ RUN set -eux; \
     cp docker/nginx/nginx.conf /etc/nginx/nginx.conf; \
     cp docker/php/index.php public/index.php; \
     cp docker/php/app /usr/local/bin/app; \
-    cp docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh; \
+    cp docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh; \
+    cp docker/php/wait-for-it.sh /usr/local/bin/wait-for-it.sh; \
     mkdir -p /run/php/ /data; \
     chmod +x /usr/local/bin/app /usr/local/bin/docker-entrypoint.sh; \
     usermod -d /var/www www-data; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,6 @@ COPY --chown=82:82 . /var/www/packagist/
 
 RUN composer run-script auto-scripts && \
     mkdir var/composer var/zipball && \
-    chown www-data:www-data -R public var && \
     rm -rf /root/.composer var/cache
 
 RUN set -eux; \

--- a/README.md
+++ b/README.md
@@ -64,31 +64,28 @@ See our [Administration Demo](https://pkg.okvpn.org). Username/password (admin/c
 Install and Run in Docker
 ------------------------
 
-Build and run docker container
+You can use [packeton/packeton](https://hub.docker.com/r/packeton/packeton) image
+
+```
+docker run -d --name packeton \
+    --mount type=volume,src=packeton-data,dst=/data \
+    -p 8080:80 \
+    packeton/packeton:latest
+```
+
+Or build and run docker container with docker-compose:
+
+- [docker-compose.yml](./docker-compose.yml) Single container example, here the container runs supervisor that to start 
+over jobs: nginx, redis, php-fpm, cron, worker. However, it does not follow the docker best-practises 
+where 1 service must be per container. But it is very easy to use and KISS principle 
+
+- [docker-compose-prod.yml](./docker-compose-prod.yml) - multiple containers, where 1 service per container
 
 ```
 docker-compose build
-docker-compose up -d
-```
 
-```yaml
-version: '3.6'
-
-services:
-    packagist:
-        build:
-            context: .
-        image: packeton/packeton:latest
-        container_name: packagist
-        hostname: packagist
-        environment:
-            ADMIN_USER: admin # create user admin on the first install
-            ADMIN_PASSWORD: 123456
-            ADMIN_EMAIL: admin@example.com
-        ports:
-            - '127.0.0.1:8088:80'
-        volumes:
-            - .docker:/data
+docker-compose up -d # Run with single supervisor container 
+docker-compose up -f docker-compose-prod.yml -d # Or split 
 ```
 
 #### Docker Environment variables

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ services:
     packagist:
         build:
             context: .
-        image: okvpn/packeton:latest
+        image: packeton/packeton:latest
         container_name: packagist
         hostname: packagist
         environment:
@@ -209,13 +209,26 @@ If you have the error ```This private key is not valid``` inserting your ssh in 
 New keys with OpenSSH private key format can be converted using ssh-keygen utility to the old PEM format.
 ```ssh-keygen -p -m PEM -f ~/.ssh/id_rsa```
 
-You can add GitHub/GitLab access token to `auth.json`, see [here](https://gist.github.com/jeffersonmartin/d0d4a8dfec90d224d14f250b36c74d2f)
+You can add GitHub/GitLab access token to `auth.json` of composer home dir 
+(default `APP_COMPOSER_HOME="%kernel.project_dir%/var/.composer"`) or use UI credentials,
+see [here](https://getcomposer.org/doc/articles/authentication-for-private-packages.md) 
 
-```
+```json
 {
     "github-oauth": {
         "github.com": "xxxxxxxxxxxxx"
     }
+}
+```
+
+#### Allow connections to http
+
+You can create `config.json` in the composer home (see `APP_COMPOSER_HOME` env var) or add this option
+in the UI credentials form.
+
+```json
+{
+    "secure-http": false
 }
 ```
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -24,10 +24,12 @@ security:
             api_basic: true
             stateless: true
             context: main
+            user_checker: Packeton\Security\UserChecker
 
         main:
             lazy: true
             pattern:      .*
+            user_checker: Packeton\Security\UserChecker
             form_login:
                 provider:       packagist
                 login_path:     /login

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -31,6 +31,7 @@ services:
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
         bind:
             $redis: '@snc_redis.default'
+            'Symfony\Component\Security\Core\User\UserCheckerInterface': '@Packeton\Security\UserChecker'
 
     Packeton\:
         resource: '../src/'

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,92 @@
+version: '3.9'
+
+x-volumes: &default-volume
+    volumes:
+        - app-data:/data
+        - app-var:/var/www/packagist/var
+
+x-restart-policy: &restart_policy
+    restart: unless-stopped
+
+x-environment: &default-environment
+    REDIS_URL: redis://redis
+    DATABASE_URL: "postgresql://packeton:pack123@postgres:5432/packeton?serverVersion=14&charset=utf8"
+    SKIP_INIT: 1
+
+services:
+    redis:
+        image: redis:7-alpine
+        hostname: redis
+        <<: *restart_policy
+        volumes:
+            - redis-data:/data
+ 
+    postgres:
+        image: postgres:14-alpine
+        hostname: postgres
+        <<: *restart_policy
+        volumes:
+            - postgres-data:/var/lib/postgresql/data
+        environment:
+            POSTGRES_USER: packeton
+            POSTGRES_PASSWORD: pack123
+            POSTGRES_DB: packeton
+
+    php-fpm:
+        image: packeton/packeton:latest
+        hostname: php-fpm
+        command: ['php-fpm', '-F']
+        <<: *restart_policy
+        <<: *default-volume
+        environment:
+            <<: *default-environment
+            SKIP_INIT: 0
+            WAIT_FOR_HOST: 'postgres:5432'
+        depends_on:
+            - "postgres"
+            - "redis"
+
+    nginx:
+        image: packeton/packeton:latest
+        hostname: nginx
+        ports:
+            - '127.0.0.1:8088:80'
+        <<: *restart_policy
+        <<: *default-volume
+        command: >
+            bash -c 'sed s/_PHP_FPM_HOST_/php-fpm:9000/g < docker/nginx/nginx-tpl.conf > /etc/nginx/nginx.conf && nginx'
+        environment:
+            <<: *default-environment
+            WAIT_FOR_HOST: 'php-fpm:9000'
+        depends_on:
+            - "php-fpm"
+
+    worker:
+        image: packeton/packeton:latest
+        hostname: packeton-worker
+        command: ['bin/console', 'packagist:run-workers', '-v']
+        <<: *restart_policy
+        <<: *default-volume
+        environment:
+            <<: *default-environment
+            WAIT_FOR_HOST: 'php-fpm:9000'
+        depends_on:
+            - "php-fpm"
+
+    cron:
+        image: packeton/packeton:latest
+        hostname: packeton-cron
+        command: ['bin/console', 'okvpn:cron', '--demand', '--time-limit=3600']
+        <<: *restart_policy
+        <<: *default-volume
+        environment:
+            <<: *default-environment
+            WAIT_FOR_HOST: 'php-fpm:9000'
+        depends_on:
+            - "php-fpm"
+
+volumes:
+    redis-data:
+    postgres-data:
+    app-data:
+    app-var:

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -x
 
+if [[ ! -z "$WAIT_FOR_HOST" ]]; then
+  wait-for-it.sh $WAIT_FOR_HOST
+fi
+
+if [[ "$SKIP_INIT" == "1" ]]; then
+  echo "Skip init application"
+  exec "$@"
+fi
+
 [ ! -d /data/redis ] && mkdir -p /data/redis
 [ ! -d /data/composer ] && mkdir /data/composer
 [ ! -d /data/zipball ] && mkdir /data/zipball
@@ -44,7 +53,7 @@ if [[ -n ${ADMIN_USER} ]]; then
   app packagist:user:manager "$ADMIN_USER" --email="$ADMIN_EMAIL" --password="$ADMIN_PASSWORD" --admin --only-if-not-exists
 fi
 
-[[ "$DATABASE_URL" == *"postgresql"* ]] && app doctrine:query:sql "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch" -vvv || true
+[[ "$DATABASE_URL" == *"postgresql"* ]] && app dbal:run-sql "CREATE EXTENSION IF NOT EXISTS fuzzystrmatch" -vvv || true
 
 chown www-data:www-data -R var /data
 chown redis:redis -R /data/redis

--- a/docker/nginx/nginx-tpl.conf
+++ b/docker/nginx/nginx-tpl.conf
@@ -46,7 +46,7 @@ http {
             fastcgi_index index.php;
             send_timeout 600;
             fastcgi_read_timeout 600;
-            fastcgi_pass 127.0.0.1:9000;
+            fastcgi_pass _PHP_FPM_HOST_;
         }
 
         location ~ \.php$ {

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -2,3 +2,4 @@ date.timezone="UTC"
 memory_limit=1024M
 max_execution_time=180
 short_open_tag=Off
+expose_php = off

--- a/docker/php/wait-for-it.sh
+++ b/docker/php/wait-for-it.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo -n > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# Check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+
+WAITFORIT_BUSYTIMEFLAG=""
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+    WAITFORIT_ISBUSY=1
+    # Check if busybox timeout uses -t flag
+    # (recent Alpine versions don't support -t anymore)
+    if timeout &>/dev/stdout | grep -q -e '-t '; then
+        WAITFORIT_BUSYTIMEFLAG="-t"
+    fi
+else
+    WAITFORIT_ISBUSY=0
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/docker/php/www.conf
+++ b/docker/php/www.conf
@@ -13,11 +13,9 @@ error_log = /dev/stderr
 ;                            (IPv6 and IPv4-mapped) on a specific port;
 ;   '/path/to/unix/socket' - to listen on a unix socket.
 ; Note: This value is mandatory.
-listen = /var/run/php.sock
+listen = 9000
 user = www-data
 group = www-data
-listen.owner = www-data
-listen.group = www-data
 
 ; Enable status page
 pm.status_path = /fpm-status
@@ -34,7 +32,7 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 6
+pm.max_children = 8
 
 ; The number of seconds after which an idle process will be killed.
 ; Note: Used only when pm is set to 'ondemand'

--- a/src/Composer/PackagistFactory.php
+++ b/src/Composer/PackagistFactory.php
@@ -78,20 +78,26 @@ class PackagistFactory
     {
         $config = ConfigFactory::createConfig();
 
-        if (null !== $credentials) {
-            $uid = @getmyuid();
-            $credentialsFile = rtrim($this->tmpDir, '/') . '/packeton_priv_key_' . $credentials->getId() . '_' . $uid;
-            if (!file_exists($credentialsFile)) {
-                file_put_contents($credentialsFile, $credentials->getKey());
-                chmod($credentialsFile, 0600);
-            }
-            putenv("GIT_SSH_COMMAND=ssh -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $credentialsFile");
-            ProcessExecutor::inheritEnv(['GIT_SSH_COMMAND']);
+        ProcessExecutor::inheritEnv([]);
+        putenv('GIT_SSH_COMMAND');
 
-            $config->merge(['config' => ['ssh-key-file' => $credentialsFile]]);
-        } else {
-            ProcessExecutor::inheritEnv([]);
-            putenv('GIT_SSH_COMMAND');
+        if (null !== $credentials) {
+            if ($credentials->getComposerConfig()) {
+                $config->merge(['config' => $credentials->getComposerConfig()]);
+            }
+
+            if ($credentials->getKey()) {
+                $uid = @getmyuid();
+                $credentialsFile = rtrim($this->tmpDir, '/') . '/packeton_priv_key_' . $credentials->getId() . '_' . $uid;
+                if (!file_exists($credentialsFile)) {
+                    file_put_contents($credentialsFile, $credentials->getKey());
+                    chmod($credentialsFile, 0600);
+                }
+                putenv("GIT_SSH_COMMAND=ssh -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $credentialsFile");
+                ProcessExecutor::inheritEnv(['GIT_SSH_COMMAND']);
+
+                $config->merge(['config' => ['ssh-key-file' => $credentialsFile]]);
+            }
         }
 
         return $config;

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -116,7 +116,6 @@ class PackageController extends AbstractController
      */
     public function submitPackageAction(Request $req)
     {
-        $user = $this->getUser();
         if (!$this->isGranted('ROLE_MAINTAINER')) {
             throw new AccessDeniedException();
         }
@@ -126,7 +125,10 @@ class PackageController extends AbstractController
             'action' => $this->generateUrl('submit'),
             'validation_groups' => ['Create']
         ]);
-        $package->addMaintainer($user);
+
+        if ($this->getUser() instanceof User) {
+            $package->addMaintainer($this->getUser());
+        }
 
         $form->handleRequest($req);
         if ($form->isSubmitted() && $form->isValid()) {
@@ -163,8 +165,10 @@ class PackageController extends AbstractController
 
         $package = new Package;
         $form = $this->createForm(PackageType::class, $package, ['validation_groups' => ['Create']]);
-        $user = $this->getUser();
-        $package->addMaintainer($user);
+
+        if ($this->getUser() instanceof User) {
+            $package->addMaintainer($this->getUser());
+        }
 
         $form->handleRequest($req);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -66,7 +66,7 @@ class PackageController extends AbstractController
      */
     public function listAction(Request $req)
     {
-        if (!$this->isGranted('ROLE_MAINTAINER')) {
+        if (!$this->isGranted('ROLE_FULL_CUSTOMER')) {
             throw new AccessDeniedException;
         }
 
@@ -296,7 +296,7 @@ class PackageController extends AbstractController
     public function viewPackageAction(Request $req, $name, CsrfTokenManagerInterface $csrfTokenManager)
     {
         if (preg_match('{^(?P<pkg>ext-[a-z0-9_.-]+?)/(?P<method>dependents|suggesters)$}i', $name, $match)) {
-            if (!$this->isGranted('ROLE_MAINTAINER')) {
+            if (!$this->isGranted('ROLE_FULL_CUSTOMER')) {
                 throw new AccessDeniedHttpException;
             }
             return $this->{$match['method'].'Action'}($req, $match['pkg']);
@@ -312,7 +312,7 @@ class PackageController extends AbstractController
             throw new NotFoundHttpException;
         }
 
-        if (!$this->isGranted('ROLE_MAINTAINER', $package)) {
+        if (!$this->isGranted('ROLE_FULL_CUSTOMER', $package)) {
             throw new NotFoundHttpException;
         }
 
@@ -419,7 +419,7 @@ class PackageController extends AbstractController
             return new JsonResponse(['error' => 'Access denied'], 403);
         }
 
-        $changelogBuilder = $this->get(ChangelogUtils::class);
+        $changelogBuilder = $this->container->get(ChangelogUtils::class);
         $fromVersion = $request->get('from');
         $toVersion = $request->get('to');
         if (!$toVersion) {
@@ -509,11 +509,9 @@ class PackageController extends AbstractController
      */
     public function viewPackageVersionAction(Request $req, $versionId)
     {
-        $req->getSession()->save();
-
         /** @var VersionRepository $repo  */
         $repo = $this->registry->getRepository(Version::class);
-        if (!$this->isGranted('ROLE_MAINTAINER', $repo->find($versionId))) {
+        if (!$this->isGranted('ROLE_FULL_CUSTOMER', $repo->find($versionId))) {
             throw new AccessDeniedHttpException;
         }
 

--- a/src/Controller/ProviderController.php
+++ b/src/Controller/ProviderController.php
@@ -144,7 +144,7 @@ class ProviderController extends AbstractController
                             return $versionName === $version->getVersion();
                         }
                 )->first();
-                if ($version && $this->isGranted('ROLE_MAINTAINER', $version)) {
+                if ($version && $this->isGranted('ROLE_FULL_CUSTOMER', $version)) {
                     return new BinaryFileResponse($path);
                 }
             }
@@ -152,7 +152,7 @@ class ProviderController extends AbstractController
 
         /** @var Version $version */
         foreach ($versions as $version) {
-            if (!$this->isGranted('ROLE_MAINTAINER', $version)) {
+            if (!$this->isGranted('ROLE_FULL_CUSTOMER', $version)) {
                 continue;
             }
 

--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -152,7 +152,7 @@ class UserController extends AbstractController
     public function updateAction(Request $request, #[Vars(['name' => 'username'])] User $user)
     {
         $currentUser = $this->getUser();
-        if ($currentUser->getUsername() !== $user->getUsername() && !$user->isAdmin()) {
+        if ($currentUser->getUserIdentifier() !== $user->getUserIdentifier() && !$user->isAdmin()) {
             return  $this->handleUpdate($request, $user, 'User has been saved.');
         }
 

--- a/src/Controller/WebController.php
+++ b/src/Controller/WebController.php
@@ -87,7 +87,7 @@ class WebController extends AbstractController
                 $perPage = max(0, min(100, $perPage));
             }
 
-            $allowed = $this->isGranted('ROLE_MAINTAINER') ? null :
+            $allowed = $this->isGranted('ROLE_FULL_CUSTOMER') ? null :
                 $this->registry
                     ->getRepository(Group::class)
                     ->getAllowedPackagesForUser($this->getUser(), false);
@@ -346,7 +346,7 @@ class WebController extends AbstractController
         $qb = $this->registry->getManager()->createQueryBuilder();
         $qb->from(Package::class, 'p');
         $repo = $this->registry->getRepository(Package::class);
-        if (!$this->isGranted('ROLE_MAINTAINER')) {
+        if (!$this->isGranted('ROLE_FULL_CUSTOMER')) {
             $packages = $this->registry->getRepository(Group::class)
                 ->getAllowedPackagesForUser($this->getUser());
             $qb->andWhere('p.id IN (:ids)')

--- a/src/DependencyInjection/Security/ApiHttpBasicFactory.php
+++ b/src/DependencyInjection/Security/ApiHttpBasicFactory.php
@@ -13,7 +13,7 @@ class ApiHttpBasicFactory implements AuthenticatorFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getKey()
+    public function getKey(): string
     {
         return 'api-basic';
     }
@@ -41,7 +41,7 @@ class ApiHttpBasicFactory implements AuthenticatorFactoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getPriority()
+    public function getPriority(): int
     {
         return 0;
     }

--- a/src/Entity/SshCredentials.php
+++ b/src/Entity/SshCredentials.php
@@ -31,9 +31,16 @@ class SshCredentials
     /**
      * @var string
      *
-     * @ORM\Column(name="ssh_key", type="text")
+     * @ORM\Column(name="ssh_key", type="text", nullable=true)
      */
     private $key;
+
+    /**
+     * @var array|null
+     *
+     * @ORM\Column(name="composer_config", type="json", nullable=true)
+     */
+    private $composerConfig;
 
     /**
      * @var \DateTime
@@ -45,7 +52,7 @@ class SshCredentials
     /**
      * @var string
      *
-     * @ORM\Column(name="fingerprint", type="string", length=255)
+     * @ORM\Column(name="fingerprint", type="string", length=255, nullable=true)
      */
     private $fingerprint;
 
@@ -69,7 +76,7 @@ class SshCredentials
      *
      * @param string $name
      *
-     * @return SshCredentials
+     * @return $this
      */
     public function setName($name)
     {
@@ -93,7 +100,7 @@ class SshCredentials
      *
      * @param string $key
      *
-     * @return SshCredentials
+     * @return $this
      */
     public function setKey($key)
     {
@@ -117,7 +124,7 @@ class SshCredentials
      *
      * @param \DateTime $createdAt
      *
-     * @return SshCredentials
+     * @return $this
      */
     public function setCreatedAt($createdAt)
     {
@@ -141,7 +148,7 @@ class SshCredentials
      *
      * @param string $fingerprint
      *
-     * @return SshCredentials
+     * @return $this
      */
     public function setFingerprint($fingerprint)
     {
@@ -159,5 +166,22 @@ class SshCredentials
     {
         return $this->fingerprint;
     }
-}
 
+    /**
+     * @return array|null
+     */
+    public function getComposerConfig(): ?array
+    {
+        return $this->composerConfig;
+    }
+
+    /**
+     * @param array|null $composerConfig
+     * @return $this
+     */
+    public function setComposerConfig(?array $composerConfig)
+    {
+        $this->composerConfig = $composerConfig;
+        return $this;
+    }
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -34,7 +34,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
  * @UniqueEntity(fields={"username"})
  * @UniqueEntity(fields={"email"})
  */
-class User extends BaseUser implements UserInterface, PasswordAuthenticatedUserInterface, LegacyPasswordAuthenticatedUserInterface
+class User extends BaseUser
 {
     /**
      * @ORM\Id

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -153,7 +153,7 @@ class User extends BaseUser
     public function toArray()
     {
         return array(
-            'name' => $this->getUsername(),
+            'name' => $this->getUserIdentifier(),
             'avatar_url' => $this->getGravatarUrl(),
         );
     }

--- a/src/Form/DataTransformer/GroupAclPermissionsTransformer.php
+++ b/src/Form/DataTransformer/GroupAclPermissionsTransformer.php
@@ -26,7 +26,7 @@ class GroupAclPermissionsTransformer implements DataTransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function transform($value)
+    public function transform($value): mixed
     {
         if (null === $value) {
             return '';
@@ -50,7 +50,7 @@ class GroupAclPermissionsTransformer implements DataTransformerInterface
     /**
      * {@inheritdoc}
      */
-    public function reverseTransform($value)
+    public function reverseTransform($value): mixed
     {
         if (empty($value)) {
             return $value;

--- a/src/Form/DataTransformer/JsonDataTransformer.php
+++ b/src/Form/DataTransformer/JsonDataTransformer.php
@@ -14,7 +14,7 @@ class JsonDataTransformer implements DataTransformerInterface
      */
     public function transform($data)
     {
-        if (null === $data || empty($data)) {
+        if (empty($data)) {
             return null;
         }
 
@@ -30,7 +30,7 @@ class JsonDataTransformer implements DataTransformerInterface
      */
     public function reverseTransform($data)
     {
-        if (empty($data)) {
+        if (empty($data) || !is_string($data)) {
             return null;
         }
 

--- a/src/Form/Type/CredentialType.php
+++ b/src/Form/Type/CredentialType.php
@@ -18,11 +18,17 @@ class CredentialType extends AbstractType
             ->setDefaults([
                 'class' => SshCredentials::class,
                 'choice_label' => function (SshCredentials $credentials) {
-                    return $credentials->getName() . ($credentials->getFingerprint() ?
-                        (' (' . $credentials->getFingerprint() . ')') : '');
+                    $label = $credentials->getName();
+                    if ($credentials->getFingerprint()) {
+                        $label = $label . "(SSH_KEY {$credentials->getFingerprint()})";
+                    } elseif ($credentials->getComposerConfig()) {
+                        $label = $label . "(Composer Auth)";
+                    }
+
+                    return $label;
                 },
-                'label' => 'Overwrite SSH Credentials',
-                'tooltip' => 'Optional, support only for Git 2.3+, to use other IdentityFile from env. GIT_SSH_COMMAND. By default will be used system ssh key',
+                'label' => 'Overwrite Composer/SSH Credentials',
+                'tooltip' => 'Optional, SSH overwrite support only for Git 2.3+, to use other IdentityFile from env. GIT_SSH_COMMAND. By default will be used system ssh key',
                 'required' => false,
             ]);
     }

--- a/src/Form/Type/SshKeyCredentialType.php
+++ b/src/Form/Type/SshKeyCredentialType.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace Packeton\Form\Type;
 
+use Composer\Json\JsonFile;
+use JsonSchema\Validator;
 use Packeton\Entity\SshCredentials;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Callback;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 class SshKeyCredentialType extends AbstractType
 {
@@ -22,7 +26,35 @@ class SshKeyCredentialType extends AbstractType
             ->add('name', TextType::class, [
                 'constraints' => [new NotBlank()]
             ])
-            ->add('key', PrivateKeyType::class);
+            ->add('replace', CredentialType::class, [
+                'mapped' => false,
+                'label' => 'Replace existing',
+                'tooltip' => 'Update existing credentials with this values. (Safe alternative for edit action)'
+            ])
+            ->add('key', PrivateKeyType::class, [
+                'attr' => ['placeholder' => "-----BEGIN RSA PRIVATE KEY-----\n....", 'rows' => 5],
+                'label' => '(optional) Private SSH Key for Git',
+                'required' => false,
+            ]);
+
+        $example = <<<TXT
+{
+  "http-basic": {
+    "gitea.company.org": {
+      "username": "user", 
+      "password": "access_token"
+    }
+  ....
+TXT;
+
+        $builder
+            ->add('composerConfig', JsonTextType::class, [
+                'attr' => ['placeholder' => $example, 'rows' => 7],
+                'label' => '(optional) Composer auth.json/config.json',
+                'required' => false,
+                'constraints' => [new Callback([$this, 'validateComposerJson'])]
+            ]);
+
     }
 
     /**
@@ -31,5 +63,46 @@ class SshKeyCredentialType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefault('data_class', SshCredentials::class);
+        $resolver->setDefault('constraints', [new Callback([$this, 'validateCredential'])]);
+    }
+
+    public function validateComposerJson($value, ExecutionContextInterface $context): void
+    {
+        if (!is_array($value)) {
+            return;
+        }
+
+        $config = json_decode(json_encode($value));
+        $validator = new Validator();
+
+        $schemaFile = 'file://' . JsonFile::COMPOSER_SCHEMA_PATH;
+        $schemaData = (object) ['$ref' => $schemaFile.'#/properties/config', '$schema' => "https://json-schema.org/draft-04/schema#"];
+        $schemaData->additionalProperties = false;
+
+        $validator->check($config, $schemaData);
+        if (!$validator->isValid()) {
+            foreach ((array) $validator->getErrors() as $error) {
+                $context->addViolation(($error['property'] ? $error['property'].' : ' : '').$error['message']);
+            }
+        }
+
+        $keys = array_keys($value);
+        if ($keys = array_intersect($keys, ['cache-dir', 'cache-files-dir', 'data-dir', 'cache-repo-dir', 'cache-vcs-dir',
+            'cache-files-ttl', 'cache-files-maxsize', 'cache-read-only', 'archive-dir', 'cafile', 'capath', 'store-auths',
+            'use-parent-dir', 'allow-plugins', 'use-parent-dir', 'home'])
+        ) {
+            $context->addViolation("This key is not allowed here: " . json_encode(array_values($keys)));
+        }
+    }
+
+    public function validateCredential($value, ExecutionContextInterface $context): void
+    {
+        if (!$value instanceof SshCredentials) {
+            return;
+        }
+
+        if (empty($value->getKey()) && empty($value->getComposerConfig())) {
+            $context->addViolation('At least SSH Key or Composer auth must be not empty');
+        }
     }
 }

--- a/src/Model/BaseUser.php
+++ b/src/Model/BaseUser.php
@@ -12,8 +12,11 @@
 namespace Packeton\Model;
 
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\User\LegacyPasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
-abstract class BaseUser
+abstract class BaseUser implements UserInterface, PasswordAuthenticatedUserInterface, LegacyPasswordAuthenticatedUserInterface
 {
     const ROLE_DEFAULT = 'ROLE_USER';
     const ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN';
@@ -61,7 +64,7 @@ abstract class BaseUser
      * Encrypted password. Must be persisted.
      *
      * @var string
-     * @ORM\Column(name="password", type="string", length=255)
+     * @ORM\Column(name="password", type="string", length=255, nullable=true)
      */
     protected $password;
 

--- a/src/Model/PackageManager.php
+++ b/src/Model/PackageManager.php
@@ -158,7 +158,7 @@ class PackageManager
      */
     public function getPackageJson(?User $user, string $package)
     {
-        if ($user && $this->authorizationChecker->isGranted('ROLE_MAINTAINER')) {
+        if ($user && $this->authorizationChecker->isGranted('ROLE_FULL_CUSTOMER')) {
             $user = null;
         }
 
@@ -229,7 +229,7 @@ class PackageManager
 
     private function dumpInMemory(User $user = null, bool $cache = true)
     {
-        if ($user && $this->authorizationChecker->isGranted('ROLE_MAINTAINER')) {
+        if ($user && $this->authorizationChecker->isGranted('ROLE_FULL_CUSTOMER')) {
             $user = null;
         }
 
@@ -239,7 +239,7 @@ class PackageManager
         }
 
         $data = $this->dumper->dump($user);
-        $this->redis->setex($cacheKey, 3600, json_encode($data));
+        $this->redis->setex($cacheKey, 900, json_encode($data));
         return $data;
     }
 }

--- a/src/Model/PackageManager.php
+++ b/src/Model/PackageManager.php
@@ -19,6 +19,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Twig\Environment;
 
 class PackageManager
@@ -128,7 +129,7 @@ class PackageManager
         return true;
     }
 
-    public function getRootPackagesJson(User $user = null)
+    public function getRootPackagesJson(UserInterface $user = null)
     {
         $packagesData = $this->dumpInMemory($user, false);
         return $packagesData[0];
@@ -139,7 +140,7 @@ class PackageManager
      * @param string $hash
      * @return bool
      */
-    public function getProvidersJson(?User $user, $hash)
+    public function getProvidersJson(?UserInterface $user, $hash)
     {
         list($root, $providers) = $this->dumpInMemory($user);
         $rootHash = \reset($root['provider-includes']);
@@ -151,12 +152,12 @@ class PackageManager
     }
 
     /**
-     * @param null|User|object $user
+     * @param null|UserInterface|object $user
      * @param string $package
      *
      * @return array
      */
-    public function getPackageJson(?User $user, string $package)
+    public function getPackageJson(?UserInterface $user, string $package)
     {
         if ($user && $this->authorizationChecker->isGranted('ROLE_FULL_CUSTOMER')) {
             $user = null;
@@ -165,7 +166,7 @@ class PackageManager
         return $this->dumper->dumpPackage($user, $package);
     }
 
-    public function getPackageV2Json(?User $user, string $package, bool $isDev = true, &$lastModified = null): array
+    public function getPackageV2Json(?UserInterface $user, string $package, bool $isDev = true, &$lastModified = null): array
     {
         if (!$metadata = $this->getCachedPackageJson($user, $package)) {
             $metadata = $this->getPackageJson($user, $package);
@@ -208,13 +209,13 @@ class PackageManager
     }
 
     /**
-     * @param User|null|object $user
+     * @param UserInterface|null|object $user
      * @param string $package
      * @param string|null $hash
      *
      * @return mixed
      */
-    public function getCachedPackageJson(?User $user, string $package, string $hash = null)
+    public function getCachedPackageJson(?UserInterface $user, string $package, string $hash = null)
     {
         [$root, $providers, $packages] = $this->dumpInMemory($user);
 
@@ -227,13 +228,13 @@ class PackageManager
         return $packages[$package];
     }
 
-    private function dumpInMemory(User $user = null, bool $cache = true)
+    private function dumpInMemory(UserInterface $user = null, bool $cache = true)
     {
         if ($user && $this->authorizationChecker->isGranted('ROLE_FULL_CUSTOMER')) {
             $user = null;
         }
 
-        $cacheKey = 'pkg_user_cache_' . ($user ? $user->getId() : 0);
+        $cacheKey = 'pkg_user_cache_' . ($user ? $user->getUserIdentifier() : 0);
         if ($cache and $data = $this->redis->get($cacheKey)) {
             return json_decode($data, true);
         }

--- a/src/Package/InMemoryDumper.php
+++ b/src/Package/InMemoryDumper.php
@@ -11,6 +11,7 @@ use Packeton\Entity\User;
 use Packeton\Entity\Version;
 use Packeton\Security\Acl\PackagesAclChecker;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
 
 class InMemoryDumper
 {
@@ -21,22 +22,22 @@ class InMemoryDumper
     ) {}
 
     /**
-     * @param User|null $user
+     * @param UserInterface|null $user
      * @return array
      */
-    public function dump(User $user = null): array
+    public function dump(UserInterface $user = null): array
     {
         return $this->dumpRootPackages($user);
     }
 
     /**
-     * @param null|User $user
+     * @param null|UserInterface $user
      * @param string|Package $package
      * @param array $versionData
      *
      * @return array
      */
-    public function dumpPackage(?User $user, $package, array $versionData = null): array
+    public function dumpPackage(?UserInterface $user, $package, array $versionData = null): array
     {
         if (is_string($package)) {
             $package = $this->registry
@@ -48,7 +49,7 @@ class InMemoryDumper
             return [];
         }
 
-        if ($user !== null && $this->checker->isGrantedAccessForPackage($user, $package) === false) {
+        if ($user !== null && (!$user instanceof User || $this->checker->isGrantedAccessForPackage($user, $package) === false)) {
             return [];
         }
 
@@ -72,7 +73,7 @@ class InMemoryDumper
         return $packageData;
     }
 
-    private function dumpRootPackages(User $user = null)
+    private function dumpRootPackages(UserInterface $user = null)
     {
         [$providers, $packagesData, $availablePackages] = $this->dumpUserPackages($user);
 
@@ -95,7 +96,7 @@ class InMemoryDumper
         return [$rootFile, $providers, $packagesData];
     }
 
-    private function dumpUserPackages(User $user = null): array
+    private function dumpUserPackages(UserInterface $user = null): array
     {
         $packages = $user ?
             $this->registry->getRepository(Group::class)

--- a/src/Repository/GroupRepository.php
+++ b/src/Repository/GroupRepository.php
@@ -49,8 +49,12 @@ class GroupRepository extends \Doctrine\ORM\EntityRepository
      *
      * @return Package[]
      */
-    public function getAllowedPackagesForUser(UserInterface $user, $hydration = true)
+    public function getAllowedPackagesForUser(?UserInterface $user, $hydration = true)
     {
+        if (!$user instanceof User) {
+            return [];
+        }
+
         $qb = $this->_em->createQueryBuilder();
         $qb
             ->select('p.id')

--- a/src/Repository/GroupRepository.php
+++ b/src/Repository/GroupRepository.php
@@ -25,13 +25,15 @@ class GroupRepository extends \Doctrine\ORM\EntityRepository
         $qb = $this->_em->createQueryBuilder();
         $qb
             ->select('acl.version')
-            ->distinct(true)
+            ->distinct()
             ->from(User::class, 'u')
             ->innerJoin('u.groups', 'g')
             ->innerJoin('g.aclPermissions', 'acl')
             ->innerJoin('acl.package', 'p')
-            ->where($qb->expr()->eq('u.id', $user->getId()))
-            ->andWhere($qb->expr()->eq('p.id', $package->getId()));
+            ->where('u.id = :uid')
+            ->andWhere('p.id = :pid')
+            ->setParameter('pid', $package->getId())
+            ->setParameter('uid', $user->getId());
 
         $result = $qb->getQuery()->getResult();
         if ($result) {
@@ -63,7 +65,7 @@ class GroupRepository extends \Doctrine\ORM\EntityRepository
         if ($hydration && $result) {
             $qb = $this->_em->createQueryBuilder();
             $qb->select('p')
-                ->from(User::class, 'p')
+                ->from(Package::class, 'p')
                 ->where('p.id IN (:ids)')
                 ->setParameter('ids', array_column($result, 'id'));
 

--- a/src/Security/UserChecker.php
+++ b/src/Security/UserChecker.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Security;
+
+use Packeton\Entity\User;
+use Symfony\Component\Security\Core\Exception\AccountExpiredException;
+use Symfony\Component\Security\Core\Exception\DisabledException;
+use Symfony\Component\Security\Core\User\UserCheckerInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class UserChecker implements UserCheckerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function checkPreAuth(UserInterface $user): void
+    {
+        if (!$user instanceof User) {
+            return;
+        }
+
+        if (!$user->isEnabled()) {
+            $ex = new DisabledException('User account is disabled.');
+            $ex->setUser($user);
+            throw $ex;
+        }
+
+        if (!$user->isAccountNonExpired()) {
+            $ex = new AccountExpiredException('User account has expired.');
+            $ex->setUser($user);
+            throw $ex;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function checkPostAuth(UserInterface $user): void
+    {
+    }
+}

--- a/src/Validator/Constraint/PackageRepositoryValidator.php
+++ b/src/Validator/Constraint/PackageRepositoryValidator.php
@@ -81,14 +81,6 @@ class PackageRepositoryValidator extends ConstraintValidator
                 return;
             }
 
-            if (preg_match('{(free.*watch|watch.*free|movie.*free|free.*movie|watch.*movie|watch.*full|generate.*resource|generate.*unlimited|hack.*coin|coin.*hack|v[.-]?bucks|(fortnite|pubg).*free|hack.*cheat|cheat.*hack|putlocker)}i', $information['name'])) {
-                $this->context->buildViolation('The package name '.htmlentities($information['name'], ENT_COMPAT, 'utf-8').' is blocked, if you think this is a mistake please get in touch with us.')
-                    ->atPath($property)
-                    ->addViolation()
-                ;
-                return;
-            }
-
             $reservedNames = ['nul', 'con', 'prn', 'aux', 'com1', 'com2', 'com3', 'com4', 'com5', 'com6', 'com7', 'com8', 'com9', 'lpt1', 'lpt2', 'lpt3', 'lpt4', 'lpt5', 'lpt6', 'lpt7', 'lpt8', 'lpt9'];
             $bits = explode('/', strtolower($information['name']));
             if (in_array($bits[0], $reservedNames, true) || in_array($bits[1], $reservedNames, true)) {

--- a/templates/user/sshkey.html.twig
+++ b/templates/user/sshkey.html.twig
@@ -1,13 +1,39 @@
 {% extends "layout.html.twig" %}
 
 {% block content %}
-    <h2 class="title">Add ssh keys</h2>
+    <h2 class="title">Add composer git/ssh credentials</h2>
     <section class="row">
         {{ form_start(form, { attr: { class: 'col-md-6' } }) }}
         {{ form_rest(form) }}
         <input class="btn btn-block btn-success btn-lg" type="submit" value="ADD KEY" />
-        {{ form_end(form) }}
+            {{ form_end(form) }}
         <div class="col-md-6">
+            <h4>Git SSH Key</h4>
+            <p>
+                Application requires the keys to be in PEM format. You receive the following error
+                <code>"This private key is not valid"</code> because the ssh key was generated with newer OpenSSH.
+                New keys with OpenSSH private key format can be converted using ssh-keygen utility to the old PEM format.
+            </p>
+            <pre>
+cp ~/.ssh/id_rsa id_rsa.pem
+ssh-keygen -p -m PEM -f id_rsa.pem
+cat id_rsa.pem
+</pre>
+            <br>
+
+            <h4>Composer auth config</h4>
+            <p>
+                You can overwrite global authentication credentials <code>auth.json</code> <br>
+                This value must be a valid JSON and manually editing this value may result in invalid json errors, so
+                you can find the location of your global auth.json and copy generated value.
+                See <a href="https://getcomposer.org/doc/articles/authentication-for-private-packages.md" target="_blank">Authentication for privately hosted repositories</a>
+            </p>
+            <pre>
+{
+    "http-basic": {
+        "example.org": {"username": "user", "password": "pass"}
+    }
+}</pre>
         </div>
     </section>
 {% endblock %}

--- a/templates/user/update.html.twig
+++ b/templates/user/update.html.twig
@@ -9,11 +9,12 @@
     <h2 class="title">{{ title }}</h2>
     <section class="row">
         {{ form_start(form, { attr: { class: 'col-md-6' } }) }}
-        {{ form_row(form.email) }}
         {{ form_row(form.username) }}
+        {{ form_row(form.email) }}
         {{ form_row(form.plainPassword) }}
         {{ form_row(form.expiredUpdatesAt) }}
         {{ form_row(form.enabled) }}
+        {{ form_row(form.fullAccess) }}
         {{ form_row(form.expiresAt) }}
         {{ form_row(form.groups) }}
         <input class="btn btn-block btn-success btn-lg" type="submit" value="{{ 'submit.submit'|trans }}" />


### PR DESCRIPTION
Fixes: #24, Fixes #23

- allow to set composer config, for example `secure-http` for allow HTTP URLs
- allow to overwrite authentication for privately hosted repos 
- added ROLE_FULL_CUSTOMER to give read access to all packages metadata
- more improvements

![Selection_1144](https://user-images.githubusercontent.com/21358010/210466107-7295982b-f845-4601-90f8-caa9a1173e2f.png)
