### PR TITLE
Fix issue with pagination

### DIFF
--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -39,7 +39,7 @@ class GroupController extends AbstractController
         $paginator->setMaxPerPage(10);
         $csrfForm = $this->createFormBuilder([])->getForm();
 
-        $paginator->setCurrentPage($page);
+        $paginator->setCurrentPage((int)$page);
 
         return $this->render('group/index.html.twig', [
             'groups' => $paginator,


### PR DESCRIPTION
Fix the following issue during pagination

Pagerfanta\Pagerfanta::setCurrentPage(): Argument https://github.com/mrodespin/packeton/pull/1 ($currentPage) must be of type int, string given, called in /Users/i4marc/Sites/projects-develop/packages-81/src/Controller/GroupController.php on line 42

![Captura de pantalla 2023-02-14 a las 10 47 46](https://user-images.githubusercontent.com/31536387/218700088-6572c7fd-bb6f-400d-94c4-9a5069891cec.png)
