### PR TITLE
Fix issue "1118 Row size too large" creating/updating database in mysql

### DIFF
--- a/src/Entity/Webhook.php
+++ b/src/Entity/Webhook.php
@@ -43,7 +43,7 @@ class Webhook implements OwnerAwareInterface
     /**
      * @var string
      *
-     * @ORM\Column(name="url", type="string", length=8000)
+     * @ORM\Column(name="url", type="text")
      */
     private $url;
 
@@ -64,7 +64,7 @@ class Webhook implements OwnerAwareInterface
     /**
      * @var string|null
      *
-     * @ORM\Column(name="package_restriction", type="string", length=8000, nullable=true)
+     * @ORM\Column(name="package_restriction", type="text", nullable=true)
      */
     private $packageRestriction;
 


### PR DESCRIPTION
Change to fix the following issue that occurs in MySQL when creating/update the database

`12:16:09 CRITICAL  [console] Error thrown while running command "doctrine:schema:update --force --env=prod --no-debug --complete". Message: "An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1118 Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs" ["exception" => Doctrine\DBAL\Exception\DriverException^ { …},"command" => "doctrine:schema:update --force --env=prod --no-debug --complete","message" => "An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1118 Row size too large. The maximum row size for the used table type, not counting BLOBs, is 65535. This includes storage overhead, check the manual. You have to change some columns to TEXT or BLOBs"]`