### PR TITLE
LDAP. Check default password if user is loaded from local database 

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -186,3 +186,6 @@ services:
                 autoescape: false
         calls:
             - [addExtension, ['@packeton.twig.webhook_sandbox']]
+    
+    Packeton\Security\CheckLdapCredentialsListener:
+        autoconfigure: false

--- a/src/Command/UserManagerCommand.php
+++ b/src/Command/UserManagerCommand.php
@@ -110,7 +110,7 @@ HELP
                 $user->setPassword($this->passwordHasher->hashPassword($user, $password));
             }
 
-            if ($input->hasOption('enabled')) {
+            if ($input->hasOption('enabled') && null !== $input->getOption('enabled')) {
                 $user->setEnabled((bool) $input->getOption('enabled'));
             }
 

--- a/src/DependencyInjection/CompilerPass/LdapServicesPass.php
+++ b/src/DependencyInjection/CompilerPass/LdapServicesPass.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\DependencyInjection\CompilerPass;
+
+use Packeton\Security\CheckLdapCredentialsListener;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class LdapServicesPass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container): void
+    {
+        $serviceId = 'security.listener.form_login_ldap.main';
+        if (!$container->hasDefinition($serviceId)) {
+            return;
+        }
+
+        $container->getDefinition($serviceId)->setClass(CheckLdapCredentialsListener::class);
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -6,6 +6,7 @@ use Packeton\DBAL\OpensslCrypter;
 use Packeton\DBAL\Types\EncryptedArrayType;
 use Packeton\DBAL\Types\EncryptedTextType;
 use Packeton\DependencyInjection\CompilerPass\ApiFirewallCompilerPass;
+use Packeton\DependencyInjection\CompilerPass\LdapServicesPass;
 use Packeton\DependencyInjection\CompilerPass\WorkerLocatorPass;
 use Packeton\DependencyInjection\PacketonExtension;
 use Packeton\DependencyInjection\Security\ApiHttpBasicFactory;
@@ -73,6 +74,7 @@ class Kernel extends BaseKernel
 
         $container->registerExtension(new PacketonExtension());
 
+        $container->addCompilerPass(new LdapServicesPass());
         $container->addCompilerPass(new ApiFirewallCompilerPass());
         $container->addCompilerPass(new WorkerLocatorPass());
     }

--- a/src/Security/CheckLdapCredentialsListener.php
+++ b/src/Security/CheckLdapCredentialsListener.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Security;
+
+use Packeton\Entity\User;
+use Symfony\Component\Ldap\Security\CheckLdapCredentialsListener as SfCheckLdapCredentialsListener;
+use Symfony\Component\Ldap\Security\LdapBadge;
+use Symfony\Component\Security\Core\Exception\BadCredentialsException;
+use Symfony\Component\Security\Http\Authenticator\Passport\Credentials\PasswordCredentials;
+use Symfony\Component\Security\Http\Event\CheckPassportEvent;
+
+/**
+ * Decorate default LdapCredentialsListener. If  LDAP password login is failed,
+ * then try to use next default system user CheckCredentialsListener if user was loaded from a database
+ */
+class CheckLdapCredentialsListener extends SfCheckLdapCredentialsListener
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function onCheckPassport(CheckPassportEvent $event): void
+    {
+        $passport = $event->getPassport();
+
+        try {
+            parent::onCheckPassport($event);
+        } catch (BadCredentialsException $e) {
+            $user = $passport->getUser();
+
+            // Only if user exists in the local database, fallback to CheckCredentialsListener
+            if ($user instanceof User && $passport->hasBadge(LdapBadge::class) && $passport->hasBadge(PasswordCredentials::class)) {
+                if ($passport->getBadge(PasswordCredentials::class)->isResolved()) {
+                    throw new \LogicException('LDAP authentication password verification cannot be completed because something else has already resolved the PasswordCredentials.');
+                }
+
+                $ldapBadge = $passport->getBadge(LdapBadge::class);
+                $ldapBadge->markResolved();
+                return;
+            }
+
+            throw $e;
+        }
+    }
+}


### PR DESCRIPTION
After deprecate the `DaoAuthenticationProvider` symfony check a password in the first LDAP listener even if the user is loaded from the database and does not exists in LDAP provider. Here fixed check a password logic to allow use local database password if user is not exists LDAP and LDAP authentication failed 
Fixes #64 