### PR TITLE
fix: Update and add basic repo automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# People marked here will be automatically requested for a review
+# when the code that they own is touched.
+# https://github.com/blog/2392-introducing-code-owners
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+* @vtsykun

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels: []

--- a/.github/workflows/docker_hub.yaml
+++ b/.github/workflows/docker_hub.yaml
@@ -25,12 +25,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache-qemu
-          key: ${{ runner.os }}-buildx-cache-qemu
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker_hub.yaml
+++ b/.github/workflows/docker_hub.yaml
@@ -15,57 +15,52 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
           platforms: arm64
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache-qemu
           key: ${{ runner.os }}-buildx-cache-qemu
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Calculate docker image tag
-        id: set-tag
-        uses: docker/metadata-action@master
+        id: docker_meta
+        uses: docker/metadata-action@v5
         with:
           images: packeton/packeton
           flavor: |
             latest=false
           tags: |
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
-            type=pep440,pattern={{major}}.{{minor}}
+            type=pep440,pattern={{ version }}
+            type=pep440,pattern={{ major }}.{{ minor }}
 
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
-#          file: "Dockerfile"
+          file: Dockerfile
           push: true
-          tags: "${{ steps.set-tag.outputs.tags }}"
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache-qemu
-          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+          cache-from: type=gha,scope=${{ github.workflow }}
+          cache-to: type=gha,scope=${{ github.workflow }},mode=max
 
           # Issue https://github.com/rust-lang/cargo/issues/10583
           build-args: |
             CARGO_NET_GIT_FETCH_WITH_CLI=true
-
-        # https://github.com/docker/build-push-action/issues/252
-        # https://github.com/moby/buildkit/issues/1896
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache-qemu
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache-qemu


### PR DESCRIPTION
Hi! Awesome project.

I've noticed that you are running quite old versions of the some docker build tools.
I've updated these in this PR.

Also added / changed the following.
- Added CODEOWNERS; mainly for GitHub auto PR review notifications.
- Added dependabot for github-actions; this will ensure it will be kept up to date.
- Updated the docker build workflow:
  - Removed the wonky docker cache steps and added back `type=gha`cache. I/we use this and it works every good.
  - Added labels to the images; this will add opencontainer labels to the docker images. This is mainly useful for image scanners and other tooling (we use some)
  - Added the full version to the tags. (2.5.1, 2.5) so when you release a patch it will be uploaded to DockerHub separately. 

Let me know if you have any questions or comments!
_hoping to maybe contribute a little bit more in the future_