### PR TITLE
Possibility to fetch dependents data as json and via API

### DIFF
--- a/src/Controller/Api/ApiForwardController.php
+++ b/src/Controller/Api/ApiForwardController.php
@@ -27,6 +27,12 @@ class ApiForwardController extends AbstractController
         return $this->forward('Packeton\Controller\PackageController::viewPackageAction', ['name' => $name, '_format' => 'json']);
     }
 
+    #[Route('/packages/{name}/dependents', name: 'packages_item', requirements: ['name' => '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?|ext-[A-Za-z0-9_.-]+?)'], methods: ['GET'])]
+    public function dependents(string $name)
+    {
+        return $this->forward('Packeton\Controller\PackageController::dependentsAction', ['name' => $name, '_format' => 'json']);
+    }
+
     #[Route('/packages/{name}/changelog', name: 'packages_changelog', requirements: ['name' => '%package_name_regex%'], methods: ['GET'])]
     public function changelog(#[Vars] Package $package, Request $request)
     {

--- a/src/Controller/Api/ApiForwardController.php
+++ b/src/Controller/Api/ApiForwardController.php
@@ -27,7 +27,7 @@ class ApiForwardController extends AbstractController
         return $this->forward('Packeton\Controller\PackageController::viewPackageAction', ['name' => $name, '_format' => 'json']);
     }
 
-    #[Route('/packages/{name}/dependents', name: 'packages_item', requirements: ['name' => '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?|ext-[A-Za-z0-9_.-]+?)'], methods: ['GET'])]
+    #[Route('/packages/{name}/dependents', name: 'packages_dependents', requirements: ['name' => '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?|ext-[A-Za-z0-9_.-]+?)'], methods: ['GET'])]
     public function dependents(string $name)
     {
         return $this->forward('Packeton\Controller\PackageController::dependentsAction', ['name' => $name, '_format' => 'json']);

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -939,9 +939,14 @@ class PackageController extends AbstractController
     }
 
     #[Route(
-        '/packages/{name}/dependents',
+        '/packages/{name}/dependents.{_format}',
         name: 'view_package_dependents',
-        requirements: ['name' => '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?|ext-[A-Za-z0-9_.-]+?)'],
+       requirements: [
+            'name' => '([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?|ext-[A-Za-z0-9_.-]+?)',
+            '_format' => '(json)',
+        ],
+        defaults: ['_format' => 'html'],
+        methods: ['GET']
     )]
     #[IsGranted('ROLE_FULL_CUSTOMER')]
     public function dependentsAction(Request $req, $name): Response
@@ -963,6 +968,14 @@ class PackageController extends AbstractController
 
         $data['meta'] = $this->getPackagesMetadata($data['packages']);
         $data['name'] = $name;
+
+        if ('json' === $req->getRequestFormat()) {
+            $response = new JsonResponse(['package' => $data]);
+            $response->setSharedMaxAge(12*3600);
+
+            return $response;
+        }
+
 
         return $this->render('package/dependents.html.twig', $data);
     }

--- a/src/Controller/PackageController.php
+++ b/src/Controller/PackageController.php
@@ -970,7 +970,7 @@ class PackageController extends AbstractController
         $data['name'] = $name;
 
         if ('json' === $req->getRequestFormat()) {
-            $response = new JsonResponse(['package' => $data]);
+            $response = new JsonResponse($data);
             $response->setSharedMaxAge(12*3600);
 
             return $response;

--- a/swagger/packages-api.yaml
+++ b/swagger/packages-api.yaml
@@ -83,6 +83,12 @@ paths:
             summary: 'Update a package'
             example: $PackageUpdate
             <<: *pkg-param
+
+    '/api/packages/{name}/dependents':
+        get:
+            tags: [ Packages ]
+            summary: 'View the dependents of a package'
+            <<: *pkg-param
     
     '/api/packages/{name}/changelog':
         get:


### PR DESCRIPTION
I adapted the logic how `viewPackageAction` was implemented via API forward and the JSON format return value.

The only real difference here is the `name` regex. Here I adapted the one used in the Package Controller (I am not really sure why there are different regex, I just kept the one, that was used)