### PR TITLE
use first non development version as download if possible

### DIFF
--- a/src/Entity/Package.php
+++ b/src/Entity/Package.php
@@ -536,7 +536,18 @@ class Package
 
     public function getVersionByReference(string $reference): ?Version
     {
-        return $this->versions->findFirst(fn($k, $v) => $v->getReference() === $reference);
+        /** @var ArrayCollection[] $matchedVersions */
+        $matchedVersions = $this->versions->partition(fn($k, $v) => $v->getReference() === $reference);
+
+        if (count($matchedVersions) > 0) {
+            /** @var Version $matchedVersion */
+            foreach ($matchedVersions[0] as $matchedVersion) {
+                if ($matchedVersion->isDevelopment() === false) {
+                    return $matchedVersion;
+                }
+            }
+        }
+        return $matchedVersions[0]->first();
     }
 
     /**


### PR DESCRIPTION
The problem with the first version is sometimes that the first version (depending on import) is a dev version with a source to a forbidden gitlab/github repo.
Only the non-development version omits the source and has only a dist with a download.

This results in a 401, if the zipball wants to download the dev version, not the non-development version.

```json
            "2.4.x-dev": {
                "name": "mageplaza\/module-seo-url",
                "version": "2.4.x-dev",
                "version_normalized": "2.4.9999999.9999999-dev",
                "source": {
                    "type": "git",
                    "url": "git@gitlab.com:mageplaza\/artemis\/module-seo-url.git",
                    "reference": "XXXXX"
                },
                "dist": {
                    "type": "zip",
                    "url": "https:\/\/gitlab.com\/api\/v4\/projects\/mageplaza%2Fartemis%2Fmodule-seo-url\/repository\/archive.zip?sha=XXXXX",
                    "reference": "XXXXX",
                    "shasum": ""
                },
...


            "4.1.4": {
                "name": "mageplaza\/module-seo-url",
                "version": "4.1.4",
                "version_normalized": "4.1.4.0",
                "dist": {
                    "type": "zip",
                    "url": "https:\/\/repo.mageplaza.com\/public\/dist\/mageplaza\/module-seo-url\/mageplaza-module-seo-url-XXXXX.zip",
                    "reference": "XXXXX",
                },
...

```