### PR TITLE
Fix GitHub repo links

### DIFF
--- a/templates/package/viewPackage.html.twig
+++ b/templates/package/viewPackage.html.twig
@@ -241,7 +241,7 @@
                             {% if package.gitHubWatches is not null %}
                                 <p>
                                     <span>
-                                        <a href="{{ repoUrl }}/watchers">Watchers</a>:
+                                        <a href="{{ repoUrl|replace({'.git':''}) }}/watchers">Watchers</a>:
                                     </span> {{ package.gitHubWatches|number_format(0, '.', '&#8201;')|raw }}
                                 </p>
                             {% endif %}

--- a/templates/package/viewPackage.html.twig
+++ b/templates/package/viewPackage.html.twig
@@ -158,7 +158,7 @@
                                 {% endif %}
                             </p>
 
-                            {% set repoUrl = package.browsableRepository %}
+                            {% set repoUrl = package.browsableRepository|replace({'.git':''}) %}
                             <p class="canonical">
                                 <a href="{{ repoUrl }}" title="Canonical Repository URL">{{ repoUrl|replace({'https://':'', 'http://':''}) }}</a>
                             </p>
@@ -241,7 +241,7 @@
                             {% if package.gitHubWatches is not null %}
                                 <p>
                                     <span>
-                                        <a href="{{ repoUrl|replace({'.git':''}) }}/watchers">Watchers</a>:
+                                        <a href="{{ repoUrl }}/watchers">Watchers</a>:
                                     </span> {{ package.gitHubWatches|number_format(0, '.', '&#8201;')|raw }}
                                 </p>
                             {% endif %}


### PR DESCRIPTION
This PR corrects a malformed GitHub URL by removing the unnecessary `.git` suffix from the repository URL.

### Before:

```
https://github.com/user/repo.git/watchers
https://github.com/user/repo.git/stargazers
https://github.com/user/repo.git/network
```

### After:

```
https://github.com/user/repo/watchers
https://github.com/user/repo/stargazers
https://github.com/user/repo/network
```

### Why:

GitHub does not support the `.git` suffix in web URLs for pages like `/watchers`, causing the link to break. This fix ensures that the link leads directly to the correct watchers page.