### PR TITLE
Remove temporary composer archive if target archive already exists

### DIFF
--- a/src/Composer/Archiver/ArchiveManager.php
+++ b/src/Composer/Archiver/ArchiveManager.php
@@ -119,6 +119,10 @@ class ArchiveManager extends ComposerArchiveManager
         $filesystem->ensureDirectoryExists(dirname($target));
 
         if (!$this->overwriteFiles && file_exists($target)) {
+            if (!$package instanceof RootPackageInterface) {
+                $filesystem->removeDirectory($sourcePath);
+            }
+
             return $target;
         }
 


### PR DESCRIPTION
This PR fixes the issue that the temporary composer archive is not deleted in case that the target archive already exists and should not be overwritten.  
The issue leads to a huge pileup of unused files (until system is rebooted or temporary directory is erased otherwise).