### PR TITLE
[TASK] ignore http errors when syncing remote providers

### DIFF
--- a/src/Mirror/Service/SyncProviderService.php
+++ b/src/Mirror/Service/SyncProviderService.php
@@ -69,7 +69,7 @@ class SyncProviderService
 
             return $http
                 ->add($repo->getUrl($uri))
-                ->then(fn (Response $rs) => $repo->dumpProvider($uri, $rs->getBody()), $this->onRejected);
+                ->then(fn (Response $rs) => $repo->dumpProvider($uri, $rs->getBody()), fn () => false);
         };
 
         return $this->httpLoop($providerIncludes, $repo->getConfig(), $loopCallback);


### PR DESCRIPTION
There are providers which return invalid "includes" paths in their packages.json.

This  PR is to ignore these 404s.