### PR TITLE
Add S3 storage support for mirror repository data

### DIFF
--- a/config/packages/flysystem.yaml
+++ b/config/packages/flysystem.yaml
@@ -10,6 +10,16 @@ flysystem:
             options:
                 directory: '%packeton_artifact_storage%'
 
+        local.mirror.meta:
+            adapter: 'local'
+            options:
+                directory: '%mirror_repos_meta_dir%'
+
+        local.mirror.dist:
+            adapter: 'local'
+            options:
+                directory: '%mirror_repos_dist_dir%'
+
         flysystem.base:
             adapter: 'lazy'
             options:
@@ -19,6 +29,16 @@ flysystem:
             adapter: 'lazy'
             options:
                 source: '%env(STORAGE_SOURCE)%.artifact'
+
+        flysystem.mirror.meta:
+            adapter: 'lazy'
+            options:
+                source: '%env(STORAGE_SOURCE)%.mirror.meta'
+
+        flysystem.mirror.dist:
+            adapter: 'lazy'
+            options:
+                source: '%env(STORAGE_SOURCE)%.mirror.dist'
 
 resolve:
     # deferred config loading depending on env vars
@@ -39,11 +59,27 @@ resolve:
                     bucket: '%env(STORAGE_AWS_BUCKET)%'
                     prefix: '%env(STORAGE_AWS_ARTIFACT_PREFIX)%'
 
+            s3.mirror.meta:
+                adapter: 'asyncaws'
+                options:
+                    client: 'packeton.s3.storage'
+                    bucket: '%env(STORAGE_AWS_BUCKET)%'
+                    prefix: '%env(STORAGE_AWS_MIRROR_META_PREFIX)%'
+
+            s3.mirror.dist:
+                adapter: 'asyncaws'
+                options:
+                    client: 'packeton.s3.storage'
+                    bucket: '%env(STORAGE_AWS_BUCKET)%'
+                    prefix: '%env(STORAGE_AWS_MIRROR_DIST_PREFIX)%'
+
     parameters:
         env(STORAGE_AWS_BUCKET): 'packeton-bucket'
         env(STORAGE_AWS_PREFIX): 'packeton'
         env(STORAGE_AWS_ARGS): '[]'
         env(STORAGE_AWS_ARTIFACT_PREFIX): 'artifact'
+        env(STORAGE_AWS_MIRROR_META_PREFIX): 'mirror-meta'
+        env(STORAGE_AWS_MIRROR_DIST_PREFIX): 'mirror-dist'
 
     services:
         packeton.s3.storage:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -13,6 +13,8 @@ parameters:
     env(MAILER_FROM): 'Packeton <packeton@example.com>'
     env(PUBLIC_ACCESS): false
     env(STORAGE_SOURCE): local
+    env(MIRROR_METADATA_CACHE_DIR): ~
+    env(MIRROR_DIST_CACHE_DIR): ~
 
     # twig sandbox
     security_policy_tags: ['app', 'for', 'if', 'spaceless', 'set', 'do', 'apply', 'verbatim', 'return']
@@ -41,6 +43,8 @@ parameters:
     composer_home_dir: '%env(resolve:APP_COMPOSER_HOME)%'
     mirror_repos_meta_dir: '%composer_home_dir%/proxy-meta'
     mirror_repos_dist_dir: '%composer_home_dir%/proxy-dist'
+    mirror_meta_cache_dir: '%env(MIRROR_METADATA_CACHE_DIR)%'
+    mirror_dist_cache_dir: '%env(MIRROR_DIST_CACHE_DIR)%'
 
     package_name_regex: '[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+'
     package_name_regex_v2: '[A-Za-z0-9_.-]+/[A-Za-z0-9_.~-]+'
@@ -69,6 +73,10 @@ services:
             Symfony\Component\Security\Core\User\UserCheckerInterface: '@Packeton\Security\UserChecker'
             League\Flysystem\FilesystemOperator $baseStorage: '@flysystem.base'
             League\Flysystem\FilesystemOperator $artifactStorage: '@flysystem.artifact'
+            League\Flysystem\FilesystemOperator $mirrorMetaStorage: '@flysystem.mirror.meta'
+            League\Flysystem\FilesystemOperator $mirrorDistStorage: '@flysystem.mirror.dist'
+            $mirrorMetaCacheDir: '%mirror_meta_cache_dir%'
+            $mirrorDistCacheDir: '%mirror_dist_cache_dir%'
 
     Packeton\:
         resource: '../src/'

--- a/docs/usage/storage.md
+++ b/docs/usage/storage.md
@@ -13,7 +13,42 @@ STORAGE_AWS_ARTIFACT_PREFIX=artifact
 
 STORAGE_AWS_ARGS='{"endpoint": "https://s3.waw.io.cloud.ovh.net", "accessKeyId": "xxx", "accessKeySecret": "xxx", "region": "waw"}'
 ```
-Sometimes for Artifact Repository requires direct access to files from the archive, so to 
+
+## Mirror Storage (Stateless Mode)
+
+When `STORAGE_SOURCE=s3`, mirrored repositories metadata and zipballs are also stored in S3.
+This enables running Packeton in stateless mode.
+
+Additional env vars for mirror storage (optional):
+
+```
+# S3 prefixes for mirror data (defaults shown)
+STORAGE_AWS_MIRROR_META_PREFIX=mirror-meta
+STORAGE_AWS_MIRROR_DIST_PREFIX=mirror-dist
+
+# Optional local cache directories. If empty, data is read/written directly to S3 (fully stateless).
+# Set to /tmp paths for ephemeral caching in container environments.
+MIRROR_METADATA_CACHE_DIR=
+MIRROR_DIST_CACHE_DIR=
+```
+
+Example for fully stateless deployment:
+```
+STORAGE_SOURCE=s3
+STORAGE_AWS_BUCKET=my-bucket
+MIRROR_METADATA_CACHE_DIR=
+MIRROR_DIST_CACHE_DIR=
+```
+
+Example with ephemeral local cache (recommended for performance):
+```
+STORAGE_SOURCE=s3
+STORAGE_AWS_BUCKET=my-bucket
+MIRROR_METADATA_CACHE_DIR=/tmp/mirror-meta
+MIRROR_DIST_CACHE_DIR=/tmp/mirror-dist
+```
+
+Sometimes for Artifact Repository requires direct access to files from the archive, so to
 improve performance and reduces count of S3 API requests, the all archives are cached on the local filesystem too. 
 
 If you need to use the other provider, like Google Cloud, you may add config file to `config/packages` or use `config.yaml` in data docker dir.

--- a/src/DependencyInjection/CompilerPass/MirrorsConfigCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/MirrorsConfigCompilerPass.php
@@ -41,13 +41,17 @@ final class MirrorsConfigCompilerPass implements CompilerPassInterface
         $container->setDefinition($rmpId = 'packeton.mirror_rmp.' . $name, $rmp);
 
         $container->setDefinition($dmId = 'packeton.mirror_dm.' . $name, new ChildDefinition(ZipballDownloadManager::class))
-            ->setArgument('$aliasName', $name);
+            ->setArgument('$aliasName', $name)
+            ->setArgument('$mirrorDistStorage', new Reference('flysystem.mirror.dist'))
+            ->setArgument('$mirrorDistCacheDir', '%mirror_dist_cache_dir%');
 
         $service = new ChildDefinition(RemoteProxyRepository::class);
 
         $service->setArgument('$repoConfig', ['name' => $name, 'type' => 'composer'] + $repoConfig)
             ->setArgument('$rpm', new Reference($rmpId))
-            ->setArgument('$zipballManager', new Reference($dmId));
+            ->setArgument('$zipballManager', new Reference($dmId))
+            ->setArgument('$mirrorMetaStorage', new Reference('flysystem.mirror.meta'))
+            ->setArgument('$mirrorMetaCacheDir', '%mirror_meta_cache_dir%');
 
         $container
             ->setDefinition($serviceId = $this->getMirrorServiceId($name), $service);

--- a/src/Mirror/Service/ZipballDownloadManager.php
+++ b/src/Mirror/Service/ZipballDownloadManager.php
@@ -6,6 +6,7 @@ namespace Packeton\Mirror\Service;
 
 use Composer\Package\CompletePackageInterface;
 use Composer\Package\Loader\ArrayLoader;
+use League\Flysystem\FilesystemOperator;
 use Packeton\Composer\PackagistFactory;
 use Packeton\Mirror\Exception\MetadataNotFoundException;
 use Packeton\Mirror\RemoteProxyRepository;
@@ -17,6 +18,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 class ZipballDownloadManager
 {
     protected RemoteProxyRepository $repository;
+    protected string $localCacheDir;
 
     public function __construct(
         protected SyncProviderService $service,
@@ -25,8 +27,10 @@ class ZipballDownloadManager
         protected PackagistFactory $packagistFactory,
         protected string $aliasName,
         protected string $mirrorDistDir,
+        protected FilesystemOperator $mirrorDistStorage,
+        protected ?string $mirrorDistCacheDir = null,
     ) {
-        $this->mirrorDistDir = rtrim($mirrorDistDir, '/') . '/' . $aliasName;
+        $this->localCacheDir = rtrim($mirrorDistDir, '/') . '/' . $aliasName;
     }
 
     public function setRepository(RemoteProxyRepository $repository): void
@@ -34,42 +38,139 @@ class ZipballDownloadManager
         $this->repository = $repository;
     }
 
-    // ZipArchiver only supported by composer now
-    public function distPath(string $package, string $version, string $ref, string $format = 'zip'): string
+    /**
+     * Returns stream for direct S3 access when local file unavailable.
+     *
+     * @return resource|null
+     */
+    public function distStream(string $package, string $version, string $ref, string $format = 'zip'): mixed
     {
-        $etag = \preg_replace('#[^a-z0-9-]#i', '-', $version) . '-' . \sha1($package.$version.$ref) . '.zip';
-        $distDir = $this->generatePackageDir($package);
-        $filename = $distDir . '/' . $etag;
-        if ($this->filesystem->exists($filename)) {
-            return $filename;
+        $etag = $this->buildEtag($package, $version, $ref);
+        $storageKey = $this->buildStorageKey($package, $etag);
+
+        if ($this->mirrorDistStorage->fileExists($storageKey)) {
+            return $this->mirrorDistStorage->readStream($storageKey);
         }
 
+        return null;
+    }
+
+    /**
+     * Returns local file path, downloading from upstream or S3 cache if needed.
+     */
+    public function distPath(string $package, string $version, string $ref, string $format = 'zip'): string
+    {
+        $etag = $this->buildEtag($package, $version, $ref);
+        $localPath = $this->buildLocalPath($package, $etag);
+        $storageKey = $this->buildStorageKey($package, $etag);
+
+        // Check local cache first
+        if ($this->filesystem->exists($localPath)) {
+            return $localPath;
+        }
+
+        // Check remote storage (S3)
+        if ($this->mirrorDistStorage->fileExists($storageKey)) {
+            $this->copyToLocal($storageKey, $localPath);
+            return $localPath;
+        }
+
+        // Download from upstream
+        $this->downloadFromUpstream($package, $version, $ref, $localPath);
+
+        // Upload to remote storage
+        $this->uploadToStorage($localPath, $storageKey);
+
+        return $localPath;
+    }
+
+    protected function buildEtag(string $package, string $version, string $ref): string
+    {
+        return \preg_replace('#[^a-z0-9-]#i', '-', $version) . '-' . \sha1($package . $version . $ref) . '.zip';
+    }
+
+    protected function buildStorageKey(string $package, string $etag): string
+    {
+        // Sharding based on package name hash for S3 performance
+        $hash = \sha1($package);
+        $shard = \substr($hash, 0, 2) . '/' . \substr($hash, 2, 2);
+
+        $intermediatePath = \preg_replace('#[^a-z0-9-_/]#i', '-', $package);
+
+        return \sprintf('%s/%s/%s/%s', $shard, $this->aliasName, $intermediatePath, $etag);
+    }
+
+    protected function buildLocalPath(string $package, string $etag): string
+    {
+        $intermediatePath = \preg_replace('#[^a-z0-9-_/]#i', '-', $package);
+
+        // Use cache dir if configured, otherwise use default local dir
+        $baseDir = ($this->mirrorDistCacheDir !== null && $this->mirrorDistCacheDir !== '')
+            ? \rtrim($this->mirrorDistCacheDir, '/') . '/' . $this->aliasName
+            : $this->localCacheDir;
+
+        return \sprintf('%s/%s/%s', $baseDir, $intermediatePath, $etag);
+    }
+
+    protected function copyToLocal(string $storageKey, string $localPath): void
+    {
+        $stream = $this->mirrorDistStorage->readStream($storageKey);
+        $targetDir = \dirname($localPath);
+
+        if (!$this->filesystem->exists($targetDir)) {
+            $this->filesystem->mkdir($targetDir);
+        }
+
+        $localHandle = @\fopen($localPath, 'w+b');
+        if ($localHandle) {
+            @\stream_copy_to_stream($stream, $localHandle);
+            @\fclose($localHandle);
+        }
+
+        if (\is_resource($stream)) {
+            @\fclose($stream);
+        }
+    }
+
+    protected function uploadToStorage(string $localPath, string $storageKey): void
+    {
+        if (!$this->mirrorDistStorage->fileExists($storageKey)) {
+            $stream = @\fopen($localPath, 'r');
+            if ($stream) {
+                $this->mirrorDistStorage->writeStream($storageKey, $stream);
+                @\fclose($stream);
+            }
+        }
+    }
+
+    protected function downloadFromUpstream(string $packageName, string $version, string $ref, string $filename): void
+    {
         $config = $this->repository->getConfig();
-        $packages = $this->repository->findPackageMetadata($package)?->decodeJson();
-        $packages = $packages['packages'][$package] ?? [];
+        $packages = $this->repository->findPackageMetadata($packageName)?->decodeJson();
+        $packages = $packages['packages'][$packageName] ?? [];
         $accessor = PropertyAccess::createPropertyAccessor();
 
         $search = static function ($packages, $preference) use (&$search, $accessor) {
             $candidate = null;
             [$refs, $propertyPaths] = \array_shift($preference);
-            $refs = !is_array($refs) ? [$refs] : $refs;
-            $propertyPaths = !is_array($propertyPaths) ? [$propertyPaths] : $propertyPaths;
+            $refs = !\is_array($refs) ? [$refs] : $refs;
+            $propertyPaths = !\is_array($propertyPaths) ? [$propertyPaths] : $propertyPaths;
 
             foreach ($packages as $package) {
                 $match = 0;
                 foreach ($propertyPaths as $i => $propertyPath) {
-                    $ref = $refs[$i];
+                    $refValue = $refs[$i];
                     try {
                         $expectedRef = $accessor->getValue($package, $propertyPath);
                     } catch (\Throwable) {
                         continue;
                     }
-                    if (!empty($expectedRef) && $expectedRef === $ref) {
+                    if (!empty($expectedRef) && $expectedRef === $refValue) {
                         $match++;
                     }
                 }
 
-                if ($match === count($propertyPaths)) {
+                if ($match === \count($propertyPaths)) {
                     $candidate = $package;
                     break;
                 }
@@ -96,7 +197,7 @@ class ZipballDownloadManager
         $http = $this->service->initHttpDownloader($config);
 
         $loader = new ArrayLoader();
-        [$package] = $loader->loadPackages([$candidate + ['name' => $package, 'version' => $version]]);
+        [$package] = $loader->loadPackages([$candidate + ['name' => $packageName, 'version' => $version]]);
 
         if ($mirrors = $config->getParentMirrors()) {
             $distMirrors = [];
@@ -114,7 +215,6 @@ class ZipballDownloadManager
         $this->filesystem->mkdir($targetDir);
         $urls = $package->getDistUrls();
 
-        $e = null;
         foreach ($urls as $url) {
             try {
                 $http->copy($url, $filename);
@@ -153,8 +253,6 @@ class ZipballDownloadManager
         if (false === $hasFile) {
             throw new MetadataNotFoundException('Unable to download dist from source. ' . $cause);
         }
-
-        return $filename;
     }
 
     private function createArchiveFormSource(CompletePackageInterface $package, string $url, string $saveTo, ?CredentialsInterface $cred = null): ?string
@@ -166,11 +264,5 @@ class ZipballDownloadManager
         $archiveManager->setOverwriteFiles(false);
 
         return $archiveManager->archive($package, 'zip', \dirname($saveTo), \basename($saveTo));
-    }
-
-    private function generatePackageDir(string $packageName): string
-    {
-        $intermediatePath = \preg_replace('#[^a-z0-9-_/]#i', '-', $packageName);
-        return \sprintf('%s/%s', \rtrim($this->mirrorDistDir, '/'), $intermediatePath);
     }
 }


### PR DESCRIPTION
Mirror repositories store metadata and zipballs on the local filesystem, which prevents running Packeton in stateless container deployments. When using S3 for regular package storage (`STORAGE_SOURCE=s3`), the `/data` directory still accumulates mirror data that cannot be shared across replicas.

This change extends the existing Flysystem-based S3 storage abstraction to mirror repositories. Both metadata (packages.json, provider includes, package JSON files) and distribution archives are now stored in S3 when configured.

For zipball storage, hash-based path sharding is implemented to optimize S3 performance. S3 partitions data by key prefix, so distributing files across prefixes like `ab/cd/...` prevents hot spots when mirroring large repositories like packagist.org.

Local caching is optional and configurable via `MIRROR_METADATA_CACHE_DIR` and `MIRROR_DIST_CACHE_DIR` environment variables. When empty, all operations go directly to S3 for fully stateless operation. When set to `/tmp` paths, ephemeral caching improves read performance while maintaining statelessness across container restarts.

The streaming fallback in `MirrorController` handles cases where local cache writes fail, ensuring zipball downloads still work by streaming directly from S3.

Closes issue https://github.com/vtsykun/packeton/issues/304