### PR TITLE
fix: sync SSO user roles on every login

### DIFF
--- a/src/Integrations/Security/OAuth2Authenticator.php
+++ b/src/Integrations/Security/OAuth2Authenticator.php
@@ -101,6 +101,13 @@ class OAuth2Authenticator implements InteractiveAuthenticatorInterface
                 throw new CustomUserMessageAuthenticationException('Registration is not allowed');
             }
             $user = $client->createUser($data);
+        } else {
+            // Update roles for existing SSO users on every login
+            $rolesToApply = $data['_mapped_roles'] ?? $config->roles();
+            if (!empty($rolesToApply)) {
+                $user->setRoles($rolesToApply);
+                $em->flush();
+            }
         }
 
         if ($config->hasLoginExpression()) {


### PR DESCRIPTION
When using OAuth2/OIDC integrations with claim-based role mapping, existing users' roles were only set on account creation. Subsequent logins did not update roles, so changes to group membership in the identity provider (e.g. Okta, Keycloak) were never reflected in Packeton.

This change updates existing SSO users' roles on every login using either the mapped roles from the IdP claim (_mapped_roles) or the integration's configured default_roles as a fallback.