### PR TITLE
fix(docker): remove debug flag set -x

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -x
 
 if [[ ! -z "$WAIT_FOR_HOST" ]]; then
   wait-for-it.sh $WAIT_FOR_HOST


### PR DESCRIPTION
With `set -x` enabled, the following command is logged:

```
app packagist:user:manager "$ADMIN_USER" --email="$ADMIN_EMAIL" --password="$ADMIN_PASSWORD" --admin --only-if-not-exists
```

As a result, `$ADMIN_PASSWORD` is exposed in clear text. In Kubernetes environments, this may leak sensitive credentials into logs.