### PR TITLE
fixes api change to the bitbucket rest api (CHANGE-2770)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 /phpunit.xml
 .phpunit.result.cache
 ###< phpunit/phpunit ###
+
+/.ddev/
+/config/packages/config.local.yaml

--- a/src/Integrations/Bitbucket/BitbucketIntegration.php
+++ b/src/Integrations/Bitbucket/BitbucketIntegration.php
@@ -150,7 +150,7 @@ class BitbucketIntegration implements IntegrationInterface, LoginInterface, AppI
     {
         $organizations = $this->getCached($app, 'orgs', callback: function () use ($app) {
             $accessToken = $this->refreshToken($app);
-            return $this->makeCGetRequest($accessToken, '/workspaces');
+            return $this->makeCGetRequest($accessToken, '/user/workspaces');
         });
 
         return $this->processOrganizations($organizations);
@@ -159,8 +159,8 @@ class BitbucketIntegration implements IntegrationInterface, LoginInterface, AppI
     protected function processOrganizations(array $organizations): array
     {
         return array_map(function ($org) {
-            $org['logo'] = $org['links']['avatar']['href'] ?? null;
-            $org['identifier'] = $org['slug'];
+            $org['logo'] = $org['workspace']['links']['avatar']['href'] ?? null;
+            $org['identifier'] = $org['workspace']['slug'];
             return $org;
         }, $organizations);
     }


### PR DESCRIPTION
This PR reflects the recent API change of the Bitbucket Rest API  regarding the workspaces endpoint for current users:

Deprecated: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-workspaces-get

Replacement: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-user-workspaces-get