### PR TITLE
Feat/GitHub webhook signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,8 @@ every time you push code. More simple way use group webhooks, to prevent from be
 
 | Provider  | Group webhook support | Target Path                                               |
 |-----------|-----------------------|-----------------------------------------------------------|
-| GitHub    | Yes                   | `https://example.org/api/github?token=`                   |
+| GitHub    | Yes (signature-based) | `https://example.org/api/hooks/github`                    |
+| GitHub    | Yes (legacy token)    | `https://example.org/api/github?token=`                   |
 | GitLab    | Only paid plan        | `https://example.org/api/update-package?token=`           |
 | Gitea     | Yes                   | `https://example.org/api/update-package?token=`           |
 | Bitbucket | Yes                   | `https://example.org/api/bitbucket?token=`                |
@@ -380,7 +381,18 @@ To enable the Group GitLab webhook you must have the paid plan.
 Go to your GitLab Group > Settings > Webhooks.
 Enter `https://<app>/api/update-package?token=user:token` as URL.
 
-#### GitHub Webhooks
+#### GitHub Organization Webhooks (recommended)
+For organization-wide webhooks, use signature-based authentication instead of putting a user API token in the URL.
+
+1. In Packeton, go to Settings > Incoming webhook secrets and create a secret.
+2. In GitHub, go to Organization Settings > Webhooks > Add webhook.
+3. Set the payload URL to `https://<app>/api/hooks/github`.
+4. Select `application/json`, paste the generated secret, and subscribe to push events.
+
+Packeton validates GitHub's `X-Hub-Signature-256` header before updating packages. Existing token-based webhook URLs
+remain available for backwards compatibility.
+
+#### GitHub Repository Webhooks (legacy)
 To enable the GitHub webhook go to your GitHub repository. Click the "Settings" button, click "Webhooks". 
 Add a new hook. Enter `https://<app>/api/github?token=user:token` as URL.
 

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -22,6 +22,9 @@ security:
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
+        github_webhook:
+            pattern: ^/api/hooks/github$
+            security: false
         packages:
             pattern: (^(.+\.json$|/p/|/mirror/|/zipball/|/feeds/.+(\.rss|\.atom)|/packages/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+?(\.json|/changelog)|/packages/list\.json|/packages/upload/|/downloads/|/api/))+
             api_basic:
@@ -72,6 +75,7 @@ security:
         # Maintainers
         - { path: (^(/users/(.+)/packages))+, roles: ROLE_MAINTAINER }
         - { path: (^(/users/(.+)/favorites))+, roles: ROLE_MAINTAINER }
+        - { path: ^/api/hooks/github$, roles: PUBLIC_ACCESS }
         - { path: (^(/metadata/changes.json$|/explore|/jobs/|/archive/|/api/hooks/))+, roles: ROLE_MAINTAINER }
 
         # Secured part of the site

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,6 +25,7 @@ parameters:
         - 'Packeton\Entity\SshCredentials'
         - 'Packeton\Entity\ApiToken'
         - 'Packeton\Entity\OAuthIntegration'
+        - 'Packeton\Entity\WebhookSecret'
     security_policy_forbidden_properties:
         'Packeton\Entity\User': ['apiToken', 'githubToken', 'password', 'salt']
         'Packeton\Entity\Package': ['credentials']

--- a/docs/usage/update-packages.md
+++ b/docs/usage/update-packages.md
@@ -4,7 +4,7 @@ You can use GitLab, GitHub, and Bitbucket project post-receive hook to keep your
 
 ## Into
 
-Webhook API request authorization with minimum access level `ROLE_MAINTAINER`. 
+Token-based webhook API request authorization requires a minimum access level of `ROLE_MAINTAINER`.
 You can use `token` query parameter with `<username:api_token>` to call it. 
 
 Also support Packagist.org authorization with `username` and `apiToken` query parameters.
@@ -29,7 +29,20 @@ To enable the Group GitLab webhook you must have the paid plan.
 Go to your GitLab Group > Settings > Webhooks.
 Enter `https://<app>/api/update-package?token=user:token` as URL.
 
-## GitHub Webhooks
+## GitHub Organization Webhooks (recommended)
+
+Organization webhooks can authenticate with GitHub's `X-Hub-Signature-256` header, without exposing a user API token
+in the webhook URL.
+
+1. In Packeton, go to Settings > Incoming webhook secrets and create a secret.
+2. In GitHub, go to Organization Settings > Webhooks > Add webhook.
+3. Set the payload URL to `https://<app>/api/hooks/github` and the content type to `application/json`.
+4. Paste the generated secret and subscribe to push events.
+
+The secret is shown once and stored encrypted by Packeton. Existing token-based endpoints remain available for
+backwards compatibility.
+
+## GitHub Repository Webhooks (legacy)
 To enable the GitHub webhook go to your GitHub repository. Click the "Settings" button, click "Webhooks".
 Add a new hook. Enter `https://<app>/api/github?token=user:token` as URL.
 

--- a/src/Controller/Api/ApiController.php
+++ b/src/Controller/Api/ApiController.php
@@ -11,6 +11,7 @@ use Packeton\Entity\OAuthIntegration;
 use Packeton\Entity\Package;
 use Packeton\Entity\User;
 use Packeton\Entity\Webhook;
+use Packeton\Entity\WebhookSecret;
 use Packeton\Integrations\IntegrationRegistry;
 use Packeton\Integrations\Model\AppUtils;
 use Packeton\Model\AutoHookUser;
@@ -21,6 +22,7 @@ use Packeton\Security\Provider\AuditSessionProvider;
 use Packeton\Service\JobPersister;
 use Packeton\Service\Scheduler;
 use Packeton\Service\SubRepositoryHelper;
+use Packeton\Service\WebhookSignatureValidator;
 use Packeton\Util\PacketonUtils;
 use Packeton\Webhook\HookBus;
 use Psr\Log\LoggerInterface;
@@ -150,6 +152,84 @@ class ApiController extends AbstractController
             if (!$packages = PacketonUtils::findPackagesByPayload($payload, $repo, true)) {
                 return new JsonResponse(['status' => 'error', 'message' => 'Missing or invalid payload'], 406);
             }
+        }
+
+        return $this->schedulePostJobs($packages);
+    }
+
+    #[Route('/api/hooks/github', name: 'github_secure_postreceive', methods: ['POST'])]
+    public function secureGitHubWebhookAction(Request $request, WebhookSignatureValidator $signatureValidator): Response
+    {
+        $secretRepository = $this->registry->getRepository(WebhookSecret::class);
+        $secrets = $secretRepository->findSecretValues();
+        if (!$secrets) {
+            return new JsonResponse(
+                ['status' => 'error', 'message' => 'No incoming webhook secrets are configured'],
+                Response::HTTP_SERVICE_UNAVAILABLE,
+            );
+        }
+
+        $signature = $request->headers->get(WebhookSignatureValidator::SIGNATURE_HEADER);
+        if (null === $signature || '' === $signature) {
+            $this->logger->warning('GitHub webhook signature validation failed: missing signature header', [
+                'ip' => $request->getClientIp(),
+                'user_agent' => $request->headers->get('User-Agent'),
+            ]);
+
+            return new JsonResponse(
+                ['status' => 'error', 'message' => 'Missing X-Hub-Signature-256 header'],
+                Response::HTTP_UNAUTHORIZED,
+            );
+        }
+
+        $matchedSecretId = $signatureValidator->findMatchingSecretId($request->getContent(), $signature, $secrets);
+        if (null === $matchedSecretId) {
+            $this->logger->warning('GitHub webhook signature validation failed: invalid signature', [
+                'ip' => $request->getClientIp(),
+                'user_agent' => $request->headers->get('User-Agent'),
+            ]);
+
+            return new JsonResponse(
+                ['status' => 'error', 'message' => 'Invalid signature'],
+                Response::HTTP_FORBIDDEN,
+            );
+        }
+
+        $secret = $secretRepository->find($matchedSecretId);
+        if (null !== $secret) {
+            $secret->updateLastUsedAt();
+            $this->registry->getManager()->flush();
+        }
+
+        $event = $request->headers->get('X-GitHub-Event');
+        if ('ping' === $event) {
+            return new JsonResponse(['status' => 'success', 'message' => 'Webhook configured successfully']);
+        }
+        if ('push' !== $event) {
+            return new JsonResponse(
+                ['status' => 'success', 'message' => sprintf('GitHub event "%s" ignored', $event ?? '')],
+                Response::HTTP_ACCEPTED,
+            );
+        }
+
+        $payload = $this->getJsonPayload($request);
+        if (!$payload) {
+            return new JsonResponse(
+                ['status' => 'error', 'message' => 'Missing or invalid JSON payload'],
+                Response::HTTP_NOT_ACCEPTABLE,
+            );
+        }
+
+        $packages = PacketonUtils::findPackagesByPayload(
+            $payload,
+            $this->registry->getRepository(Package::class),
+            true,
+        );
+        if (!$packages) {
+            return new JsonResponse(
+                ['status' => 'error', 'message' => 'No matching packages found'],
+                Response::HTTP_NOT_FOUND,
+            );
         }
 
         return $this->schedulePostJobs($packages);

--- a/src/Controller/WebhookSecretController.php
+++ b/src/Controller/WebhookSecretController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Controller;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Packeton\Attribute\Vars;
+use Packeton\Entity\WebhookSecret;
+use Packeton\Form\Type\WebhookSecretType;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/webhook-secrets')]
+#[IsGranted('ROLE_ADMIN')]
+class WebhookSecretController extends AbstractController
+{
+    public function __construct(
+        private readonly ManagerRegistry $registry,
+    ) {
+    }
+
+    #[Route('', name: 'webhook_secret_index', methods: ['GET'])]
+    public function indexAction(): Response
+    {
+        return $this->render('webhook_secret/index.html.twig', [
+            'secrets' => $this->registry->getRepository(WebhookSecret::class)->findAllOrdered(),
+        ]);
+    }
+
+    #[Route('/create', name: 'webhook_secret_create', methods: ['GET', 'POST'])]
+    public function createAction(Request $request): Response
+    {
+        $secret = (new WebhookSecret())->setSecret(WebhookSecret::generateSecret());
+        $form = $this->createForm(WebhookSecretType::class, $secret);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $entityManager = $this->registry->getManager();
+            $entityManager->persist($secret);
+            $entityManager->flush();
+
+            $response = $this->render('webhook_secret/show_secret.html.twig', [
+                'secret' => $secret,
+                'generatedSecret' => $secret->getSecret(),
+            ]);
+            $response->setPrivate();
+            $response->headers->addCacheControlDirective('no-store');
+
+            return $response;
+        }
+
+        return $this->render('webhook_secret/create.html.twig', [
+            'form' => $form->createView(),
+        ]);
+    }
+
+    #[Route('/{id}/delete', name: 'webhook_secret_delete', requirements: ['id' => '\d+'], methods: ['POST'])]
+    public function deleteAction(Request $request, #[Vars] WebhookSecret $secret): Response
+    {
+        if (!$this->isCsrfTokenValid('webhook_secret_delete_'.$secret->getId(), $request->request->get('_token'))) {
+            return new Response('Invalid csrf token', Response::HTTP_BAD_REQUEST);
+        }
+
+        $entityManager = $this->registry->getManager();
+        $entityManager->remove($secret);
+        $entityManager->flush();
+
+        $this->addFlash('success', 'Webhook secret deleted.');
+
+        return $this->redirectToRoute('webhook_secret_index');
+    }
+}

--- a/src/Entity/WebhookSecret.php
+++ b/src/Entity/WebhookSecret.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Packeton\Repository\WebhookSecretRepository;
+
+#[ORM\Entity(repositoryClass: WebhookSecretRepository::class)]
+#[ORM\Table(name: 'webhook_secret')]
+class WebhookSecret
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private ?string $name = null;
+
+    #[ORM\Column(type: 'encrypted_text')]
+    private ?string $secret = null;
+
+    #[ORM\Column(type: 'datetime')]
+    private \DateTimeInterface $createdAt;
+
+    #[ORM\Column(type: 'datetime', nullable: true)]
+    private ?\DateTimeInterface $lastUsedAt = null;
+
+    public function __construct()
+    {
+        $this->createdAt = new \DateTime('now', new \DateTimeZone('UTC'));
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getSecret(): ?string
+    {
+        return $this->secret;
+    }
+
+    public function setSecret(string $secret): self
+    {
+        $this->secret = $secret;
+
+        return $this;
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function getLastUsedAt(): ?\DateTimeInterface
+    {
+        return $this->lastUsedAt;
+    }
+
+    public function updateLastUsedAt(): self
+    {
+        $this->lastUsedAt = new \DateTime('now', new \DateTimeZone('UTC'));
+
+        return $this;
+    }
+
+    public static function generateSecret(): string
+    {
+        return bin2hex(random_bytes(32));
+    }
+}

--- a/src/Form/Type/WebhookSecretType.php
+++ b/src/Form/Type/WebhookSecretType.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Form\Type;
+
+use Packeton\Entity\WebhookSecret;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+class WebhookSecretType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('name', TextType::class, [
+            'label' => 'Name',
+            'help' => 'Use a descriptive name for the GitHub organization or webhook.',
+            'constraints' => [
+                new NotBlank(),
+                new Length(max: 255),
+            ],
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => WebhookSecret::class,
+        ]);
+    }
+}

--- a/src/Menu/MenuBuilder.php
+++ b/src/Menu/MenuBuilder.php
@@ -56,6 +56,7 @@ class MenuBuilder
         $menu->addChild($this->translator->trans('menu.my_groups'), ['label' => 'menu.my_groups_icon', 'route' => 'groups_index', 'extras' => ['safe_label' => true]]);
         $menu->addChild($this->translator->trans('menu.ssh_keys'), ['label' => 'menu.ssh_keys_icon', 'route' => 'user_add_sshkey', 'extras' => ['safe_label' => true]]);
         $menu->addChild($this->translator->trans('menu.webhooks'), ['label' => 'menu.webhooks_icon', 'route' => 'webhook_index', 'extras' => ['safe_label' => true]]);
+        $menu->addChild($this->translator->trans('menu.webhook_secrets'), ['label' => 'menu.webhook_secrets_icon', 'route' => 'webhook_secret_index', 'extras' => ['safe_label' => true]]);
         $menu->addChild($this->translator->trans('menu.proxies'), ['label' => 'menu.proxies_icon', 'route' => 'proxies_list', 'extras' => ['safe_label' => true]]);
         $menu->addChild($this->translator->trans('menu.subrepository'), ['label' => 'menu.subrepository_icon', 'route' => 'subrepository_index', 'extras' => ['safe_label' => true]]);
         if ($this->integrations->getNames()) {

--- a/src/Repository/WebhookSecretRepository.php
+++ b/src/Repository/WebhookSecretRepository.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Repository;
+
+use Doctrine\ORM\EntityRepository;
+use Packeton\Entity\WebhookSecret;
+
+/**
+ * @extends EntityRepository<WebhookSecret>
+ */
+class WebhookSecretRepository extends EntityRepository
+{
+    /**
+     * @return WebhookSecret[]
+     */
+    public function findAllOrdered(): array
+    {
+        return $this->createQueryBuilder('secret')
+            ->orderBy('secret.createdAt', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function findSecretValues(): array
+    {
+        $secrets = [];
+        foreach ($this->findAll() as $secret) {
+            if (null !== $secret->getId() && null !== $secret->getSecret()) {
+                $secrets[$secret->getId()] = $secret->getSecret();
+            }
+        }
+
+        return $secrets;
+    }
+}

--- a/src/Service/WebhookSignatureValidator.php
+++ b/src/Service/WebhookSignatureValidator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Service;
+
+class WebhookSignatureValidator
+{
+    public const SIGNATURE_HEADER = 'X-Hub-Signature-256';
+
+    /**
+     * @param array<int, string> $secrets
+     */
+    public function findMatchingSecretId(string $payload, string $signature, array $secrets): ?int
+    {
+        if (1 !== preg_match('/\Asha256=([A-Fa-f0-9]{64})\z/', $signature, $matches)) {
+            return null;
+        }
+
+        $providedHash = strtolower($matches[1]);
+        foreach ($secrets as $id => $secret) {
+            if (hash_equals(hash_hmac('sha256', $payload, $secret), $providedHash)) {
+                return $id;
+            }
+        }
+
+        return null;
+    }
+}

--- a/templates/about/about.html.twig
+++ b/templates/about/about.html.twig
@@ -33,7 +33,16 @@ composer config --global --auth http-basic.{{ app.request.getHttpHost() }} {{ ap
     <h2 class="title" id="how-to-update-packages">How to update packages?</h2>
     <section class="row">
         <section class="col-md-6">
-            <h3>GitHub Service Hook</h3>
+            <h3>GitHub Organization Webhook</h3>
+            <p>Organization webhooks can use an HMAC signature instead of exposing a user API token in the URL.</p>
+            <ul>
+                <li>{% if is_granted('ROLE_ADMIN') %}<a href="{{ path('webhook_secret_create') }}">Create an incoming webhook secret</a>{% else %}Ask an administrator to create an incoming webhook secret{% endif %}</li>
+                <li>Go to your GitHub organization settings and add a webhook</li>
+                <li>Enter <code>{{ url }}/api/hooks/github</code> as the payload URL</li>
+                <li>Select JSON content, enter the generated secret, and subscribe to push events</li>
+            </ul>
+
+            <h3>GitHub Repository Webhook (legacy)</h3>
             <p>Enabling the Packagist service hook ensures that your package will always be updated instantly when you push to GitHub.</p>
             <p>To do so you can:</p>
             <ul>

--- a/templates/webhook_secret/create.html.twig
+++ b/templates/webhook_secret/create.html.twig
@@ -1,0 +1,17 @@
+{% extends "layout.html.twig" %}
+
+{% block content %}
+    <h2 class="title">Add incoming webhook secret</h2>
+
+    <section class="row">
+        {{ form_start(form, {attr: {class: 'col-md-6'}}) }}
+            {{ form_rest(form) }}
+            <button class="btn btn-block btn-success btn-lg" type="submit">Create secret</button>
+        {{ form_end(form) }}
+
+        <div class="col-md-6">
+            <h4>GitHub organization webhooks</h4>
+            <p>Packeton generates the shared secret. Copy it to GitHub when it is displayed on the next page.</p>
+        </div>
+    </section>
+{% endblock %}

--- a/templates/webhook_secret/index.html.twig
+++ b/templates/webhook_secret/index.html.twig
@@ -1,0 +1,36 @@
+{% extends "layout.html.twig" %}
+
+{% block content %}
+    <section class="row">
+        <div>
+            <div style="float: right">
+                <a class="btn btn-default" href="{{ path('webhook_secret_create') }}">Add webhook secret</a>
+            </div>
+            <h3>Incoming webhook secrets</h3>
+            <p style="max-width: 65%">
+                These secrets authenticate incoming GitHub organization webhooks. Secret values are encrypted in the
+                database and are only displayed once, immediately after creation.
+            </p>
+        </div>
+
+        <div style="padding-top: 10px; clear: both"></div>
+
+        {% for secret in secrets %}
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>{{ secret.name }}</strong>
+                </div>
+                <div class="panel-body">
+                    <form style="float: right" class="onsubmit-confirm" action="{{ path('webhook_secret_delete', {id: secret.id}) }}" method="POST">
+                        <input type="hidden" name="_token" value="{{ csrf_token('webhook_secret_delete_' ~ secret.id) }}" />
+                        <button class="btn btn-danger" type="submit">Delete</button>
+                    </form>
+                    <p>Created: {{ secret.createdAt|date('Y-m-d H:i:s T') }}</p>
+                    <p>Last used: {{ secret.lastUsedAt ? secret.lastUsedAt|date('Y-m-d H:i:s T') : 'Never' }}</p>
+                </div>
+            </div>
+        {% else %}
+            <div class="alert alert-info">No incoming webhook secrets have been configured.</div>
+        {% endfor %}
+    </section>
+{% endblock %}

--- a/templates/webhook_secret/show_secret.html.twig
+++ b/templates/webhook_secret/show_secret.html.twig
@@ -1,0 +1,18 @@
+{% extends "layout.html.twig" %}
+
+{% block content %}
+    <h2 class="title">Incoming webhook secret created</h2>
+
+    <div class="alert alert-warning">
+        Copy this secret now. Packeton encrypts it for validation and will not display it again.
+    </div>
+
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>{{ secret.name }}</strong></div>
+        <div class="panel-body">
+            <code id="generated-webhook-secret" style="word-break: break-all">{{ generatedSecret }}</code>
+        </div>
+    </div>
+
+    <a class="btn btn-default" href="{{ path('webhook_secret_index') }}">Back to webhook secrets</a>
+{% endblock %}

--- a/tests/Functional/Controller/GitHubWebhookControllerTest.php
+++ b/tests/Functional/Controller/GitHubWebhookControllerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Tests\Functional\Controller;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Packeton\Entity\Package;
+use Packeton\Entity\WebhookSecret;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class GitHubWebhookControllerTest extends WebTestCase
+{
+    public function testSignedPingAuthentication(): void
+    {
+        $client = static::createClient();
+        $registry = static::getContainer()->get(ManagerRegistry::class);
+        $registry->getConnection()->executeStatement('DELETE FROM webhook_secret');
+
+        $payload = '{"zen":"Keep it logically awesome."}';
+        $this->requestWebhook($client, $payload, 'ping', 'sha256='.str_repeat('0', 64));
+        static::assertResponseStatusCodeSame(503);
+
+        $plainSecret = WebhookSecret::generateSecret();
+        $secret = (new WebhookSecret())
+            ->setName('GitHub organization')
+            ->setSecret($plainSecret);
+        $registry->getManager()->persist($secret);
+        $registry->getManager()->flush();
+
+        $this->requestWebhook($client, $payload, 'ping');
+        static::assertResponseStatusCodeSame(401);
+
+        $this->requestWebhook($client, $payload, 'ping', 'sha256=invalid');
+        static::assertResponseStatusCodeSame(403);
+
+        $this->requestWebhook($client, $payload, 'ping', 'sha256='.str_repeat('0', 64));
+        static::assertResponseStatusCodeSame(403);
+
+        $signature = 'sha256='.hash_hmac('sha256', $payload, $plainSecret);
+        $this->requestWebhook($client, $payload, 'ping', $signature);
+        static::assertResponseIsSuccessful();
+        static::assertJsonStringEqualsJsonString(
+            '{"status":"success","message":"Webhook configured successfully"}',
+            (string) $client->getResponse()->getContent(),
+        );
+
+        $registry = static::getContainer()->get(ManagerRegistry::class);
+        $registry->getManager()->clear();
+        $secret = $registry->getRepository(WebhookSecret::class)->findOneBy(['name' => 'GitHub organization']);
+        static::assertInstanceOf(WebhookSecret::class, $secret);
+        static::assertNotNull($secret->getLastUsedAt());
+
+        $package = $registry->getRepository(Package::class)->findOneBy(['name' => 'okvpn/cron-bundle']);
+        static::assertInstanceOf(Package::class, $package);
+        $pushPayload = json_encode(['repository' => ['url' => $package->getRepository()]], JSON_THROW_ON_ERROR);
+        $pushSignature = 'sha256='.hash_hmac('sha256', $pushPayload, $plainSecret);
+
+        $this->requestWebhook($client, $pushPayload, 'push', $pushSignature);
+        static::assertResponseStatusCodeSame(202);
+        $response = json_decode((string) $client->getResponse()->getContent(), true, flags: JSON_THROW_ON_ERROR);
+        static::assertSame('success', $response['status']);
+        static::assertNotEmpty($response['jobs']);
+    }
+
+    private function requestWebhook(
+        KernelBrowser $client,
+        string $payload,
+        string $event,
+        ?string $signature = null,
+    ): void {
+        $server = [
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_X_GITHUB_EVENT' => $event,
+        ];
+        if (null !== $signature) {
+            $server['HTTP_X_HUB_SIGNATURE_256'] = $signature;
+        }
+
+        $client->request('POST', '/api/hooks/github', [], [], $server, $payload);
+    }
+}

--- a/tests/Functional/Controller/WebhookSecretControllerTest.php
+++ b/tests/Functional/Controller/WebhookSecretControllerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Packeton\Tests\Functional\Controller;
+
+use Doctrine\Persistence\ManagerRegistry;
+use Packeton\Entity\WebhookSecret;
+use Packeton\Tests\Functional\PacketonTestTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class WebhookSecretControllerTest extends WebTestCase
+{
+    use PacketonTestTrait;
+
+    public function testOnlyAdminsCanManageWebhookSecrets(): void
+    {
+        $client = static::createClient();
+        $client->loginUser($this->getUser('user1'));
+
+        $client->request('GET', '/webhook-secrets');
+
+        static::assertResponseStatusCodeSame(403);
+    }
+
+    public function testAdminCanCreateEncryptedWebhookSecret(): void
+    {
+        $client = static::createClient();
+        $registry = static::getContainer()->get(ManagerRegistry::class);
+        $registry->getConnection()->executeStatement('DELETE FROM webhook_secret');
+
+        $client->loginUser($this->getUser('admin'));
+        $crawler = $client->request('GET', '/webhook-secrets/create');
+        $form = $crawler->selectButton('Create secret')->form([
+            'webhook_secret[name]' => 'GitHub organization',
+        ]);
+        $crawler = $client->submit($form);
+
+        static::assertResponseIsSuccessful();
+        static::assertTrue($client->getResponse()->headers->hasCacheControlDirective('no-store'));
+        $plainSecret = trim($crawler->filter('#generated-webhook-secret')->text());
+        static::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $plainSecret);
+
+        $storedSecret = $registry->getConnection()->fetchOne('SELECT secret FROM webhook_secret');
+        static::assertIsString($storedSecret);
+        static::assertNotSame($plainSecret, $storedSecret);
+
+        $registry->getManager()->clear();
+        $secret = $registry->getRepository(WebhookSecret::class)->findOneBy(['name' => 'GitHub organization']);
+        static::assertInstanceOf(WebhookSecret::class, $secret);
+        static::assertSame($plainSecret, $secret->getSecret());
+    }
+}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -28,6 +28,7 @@ menu:
     my_groups: My groups
     ssh_keys: Credentials
     webhooks: Webhooks
+    webhook_secrets: Incoming webhook secrets
     proxies: Composer Proxies
     subrepository: SubRepositories
     integrations: Integrations
@@ -43,6 +44,7 @@ menu:
     my_login_icon: '<span class="fa fa-desktop"></span>Login attempts'
     ssh_keys_icon: '<span class="fa fa-key"></span>Credentials'
     webhooks_icon: '<span class="fa fa-bell"></span>Webhooks'
+    webhook_secrets_icon: '<span class="fa fa-shield"></span>Incoming webhook secrets'
     subrepository_icon: '<span class="fa fa-floppy-o"></span>SubRepositories'
     break_line_icon: '<hr>'
     proxies_icon: '<span class="fa fa-random"></span>Composer Proxies'
@@ -215,4 +217,3 @@ Order: 'Order'
 Username: 'Username'
 asc: 'asc'
 desc: 'desc'
-


### PR DESCRIPTION
Add a public GitHub organization webhook endpoint that authenticates the raw request body with X-Hub-Signature-256 before scheduling package updates.

Support secret rotation, ignore non-push events safely, retain the legacy token endpoint, and document the new setup flow.